### PR TITLE
Fix release.yml: case-sensitive paths + Windows zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,19 @@ jobs:
               -name 'libpugixml.a' \) -exec cp -L {} stage/lib/ \;
 
           # Self-contained C API header (only depends on <stdint.h>)
-          cp Src/dasher.h stage/include/
+          cp src/dasher.h stage/include/
 
           echo "Staged files:"
           find stage -type f | sort
 
-          ( cd stage && zip -r "../${{ matrix.artifact }}-${VER}.zip" . )
+          # zip is absent on windows runners; 7z (7-Zip) is preinstalled.
+          cd stage
+          ZIP_NAME="../${{ matrix.artifact }}-${VER}.zip"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            7z a -tzip "$ZIP_NAME" .
+          else
+            zip -r "$ZIP_NAME" .
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -155,8 +162,8 @@ jobs:
           mkdir -p stage-wasm
           WEB=dasher-web/wasm-build
           em++ -O3 -DNDEBUG -fwasm-exceptions \
-              Src/CAPI.cpp \
-              -I Src \
+              src/CAPI.cpp \
+              -I src \
               -I Thirdparty/pugixml/src \
               build-wasm/libDasherCore.a \
               build-wasm/Thirdparty/pugixml/libpugixml.a \


### PR DESCRIPTION
Fixes three failures from the first `release.yml` dry-run ([run 27654486497](https://github.com/dasher-project/DasherCore/actions/runs/27654486497)):

1. **`Src/` → `src/`** — Linux runners are case-sensitive; the repo path is lowercase `src/`. The WASM job on Ubuntu failed with `Src/CAPI.cpp: No such file or directory`, and the Linux native job failed copying `Src/dasher.h`. Windows/macOS masked it (NTFS/APFS case-insensitive).
2. **`zip` → `7z` on Windows** — windows-latest runners ship 7-Zip but not `zip`; Windows native job failed with `zip: command not found`. Now branches on `RUNNER_OS`.

Job results from run 27654486497:
| Job | Result |
|-----|--------|
| Build (data bundle) | pass |
| Build (dasher-macos-arm64) | pass |
| Build (dasher-windows-x64) | **fail** — `zip: command not found` |
| Build (dasher-linux-x64) | **fail** — `cp: cannot stat 'Src/dasher.h'` |
| Build (wasm) | **fail** — `Src/CAPI.cpp: No such file or directory` |

This PR only touches the release workflow file (tag/dispatch triggered), so existing CI is unaffected. Will re-run via `workflow_dispatch` after merge.