### PR TITLE
Drop macOS x86_64 from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ name: Release
 #   dasher-windows-x64-v1.2.3.zip      dasher.dll + dasher.lib (import)
 #   dasher-linux-x64-v1.2.3.zip        libdasher.so
 #   dasher-macos-arm64-v1.2.3.zip      libdasher.dylib
-#   dasher-macos-x86_64-v1.2.3.zip     libdasher.dylib
 #   dasher-wasm-v1.2.3.zip             dasher.js + dasher.wasm + dasher.data
 #   dasher-data-v1.2.3.zip             full Data/ + Strings/ for runtime use
 #
@@ -41,10 +40,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macos-13 = Intel, macos-14 = Apple Silicon -> separate arch zips
+          # macOS Intel (macos-13) runners are heavily deprecated/backlogged on
+          # GitHub Actions — shipping arm64 only. Intel Mac users can build
+          # from source or run the arm64 build under Rosetta.
           - { os: windows-latest, artifact: dasher-windows-x64 }
           - { os: ubuntu-latest,  artifact: dasher-linux-x64 }
-          - { os: macos-13,       artifact: dasher-macos-x86_64 }
           - { os: macos-14,       artifact: dasher-macos-arm64 }
 
     steps:


### PR DESCRIPTION
Removes the `macos-13` (Intel) job from the release workflow matrix.

**Why:** The previous release dry-run ([run 27655433627](https://github.com/dasher-project/DasherCore/actions/runs/27655433627)) had the `dasher-macos-x86_64` job stuck in `queued` for 5+ hours — GitHub has heavily deprecated/backlogged Intel macOS runners. The other 5 jobs (windows-x64, linux-x64, macos-arm64, wasm, data) all passed.

**Impact:** Modern Macs are arm64. Intel Mac users can build from source or run the arm64 build under Rosetta. Native matrix is now: windows-x64, linux-x64, macos-arm64.

Only touches `release.yml` (tag/dispatch triggered) — existing CI unaffected.