### PR TITLE
Force Node.js 24 action runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ on:
 permissions:
   contents: read
 
+# Opt all jobs into the Node.js 24 action runtime. The actions/* v5 majors
+# still ship a node20 entry point, so without this GitHub warns on every
+# upload/download-artifact step. Flip the runner default early.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   # ── Native shared + static libraries ───────────────────────────────────
   build-native:


### PR DESCRIPTION
Clears the remaining 'Node.js 20 actions are deprecated' warnings seen in the v0.1.0 release run (27668098871).

`actions/upload-artifact@v5` and `actions/download-artifact@v5` still ship a `node20` entry point, so GitHub warns on every artifact step despite us being on the latest majors. Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` as workflow-level env (applies to all jobs) opts the runner into the Node 24 runtime — exactly what the deprecation notice recommends.

Only touches `release.yml` — existing CI unaffected.