### PR TITLE
Add null guard in CreateInputFilter

### DIFF
--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -655,6 +655,8 @@ void CDasherInterfaceBase::CreateInputFilter() {
 
     if (m_pInputFilter == nullptr) m_pInputFilter = m_pModuleManager->GetDefaultInputMethod();
 
+    if (m_pInputFilter == nullptr) return; // Modules not yet registered
+
     m_pInputFilter->Activate();
 }
 


### PR DESCRIPTION
If Realize() partially fails (e.g. ChangeAlphabet throws and the exception is caught by an outer handler), CreateModules() may never have run, leaving the module registry empty. When SetStringParameter is then called for SP_INPUT_FILTER (e.g. the CAPI forces 'Normal Control' after Realize), CreateInputFilter dereferences a null pointer and crashes.

Add an explicit null check after both lookup attempts — if no input filter module is found, return early rather than crashing.
