### PR TITLE
IsFileWriteable: probe via permission bits, not append-open

### DIFF
--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -17,8 +17,16 @@ void FileUtils::SetDataDirectory(const std::string& dataDir) {
 } // namespace Dasher
 
 static bool IsFileWriteable(const std::filesystem::path& file_path) {
-    std::fstream file(file_path.string(), std::ios_base::app | std::fstream::out);
-    return file.is_open();
+    // Check writability via permission bits without opening the file.
+    // Opening with ios_base::app|out (the previous implementation) attempted
+    // to create/append the file just to test writability, which generated
+    // sandbox deny storms against read-only bundled data on iOS keyboard
+    // extensions and could accidentally create empty files on other platforms.
+    std::error_code ec;
+    const auto status = std::filesystem::status(file_path, ec);
+    if (ec) return false;
+    using P = std::filesystem::perms;
+    return (status.permissions() & (P::owner_write | P::group_write | P::others_write)) != P::none;
 }
 
 int Dasher::FileUtils::GetFileSize(const std::string& strFileName) {


### PR DESCRIPTION
## Why

`IsFileWriteable()` tested writability by opening the file with `ios_base::app | out`. Two problems with that:

1. **Side effect:** on paths that don't yet exist, it created empty files.
2. **iOS keyboard sandbox noise:** the Dasher Apple keyboard extension ships its data bundle (alphabets, colour palettes) inside the read-only `.appex` container. Every `ScanFiles()` call probed each scanned file with an append-open, producing a `Sandbox: deny file-write-data` log line per file from the kernel. Several dozen denies per `Realize()` call.

## What this changes

Replaces the open-and-check with `std::filesystem::status()` and a permission-bit check for any write bit (owner/group/others).

- Side-effect free: never creates files.
- Faster: one `stat()` instead of `open()` + `close()`.
- Sandbox-clean: no write attempts against read-only paths.

## Compatibility

Semantically equivalent for all current callers. `ScanFiles()` only invokes `IsFileWriteable()` on entries that `recursive_directory_iterator` already returned as `is_regular_file()`, so the non-existent-file edge case doesn't arise in practice. The new code handles it anyway (returns `false` on `status()` error).

No public API change. No header change. Drop-in for all frontends (Apple, Windows, GTK, WASM).

## Verification

Built and verified on iOS via the Dasher Apple keyboard extension. Sandbox denies during `Realize()` are gone; no regressions in DasherApp, DasherMac, or DasherVision.

<!-- DCO -->