### PR TITLE
Build fixes for Android NDK (I18n.h, UserLocation.cpp)

### DIFF
--- a/src/DasherCore/Common/I18n.h
+++ b/src/DasherCore/Common/I18n.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__) || defined(__ANDROID__)
 
 #define _(szText) szText
 #define N_(szText) (szText)

--- a/src/DasherCore/UserLocation.cpp
+++ b/src/DasherCore/UserLocation.cpp
@@ -1,6 +1,5 @@
 #include "UserLocation.h"
 
-#include <sys/timeb.h>
 #include <cmath>
 
 #include "TimeSpan.h"


### PR DESCRIPTION
## Summary

Two small fixes that unblock building DasherCore with the Android NDK (needed by the new Dasher-Android frontend, which builds DasherCore with \BUILD_CAPI ON\ for arm64-v8a / x86_64).

### 1. \I18n.h\ — treat Android like iOS/Windows
\#if defined(_WIN32) || defined(__APPLE__)\ → add \|| defined(__ANDROID__)\.

Android, like iOS and Windows, has no gettext/\libintl.h\. It localises via the C API JSON runtime (\dasher_set_locale\), exactly as the Apple and Windows frontends do. Without this, the build fails at \#include <libintl.h>\ (the header is absent on the NDK).

### 2. \UserLocation.cpp\ — drop unused \<sys/timeb.h>\
The header is included but never referenced (no \time()\ / \struct timeb\ usage). \sys/timeb.h\ is deprecated and absent on the Android NDK, breaking the build. Removing the dead include is a no-op on every other platform.

## Why these are safe
- No behaviour change on Windows / macOS / Linux: \_()\ stays a no-op on Win/Apple (unchanged), and the removed include was unused everywhere.
- Android joins the same no-op-\_\ group as the other C-API frontends.

## Testing
- Verified clang-format clean against the repo \.clang-format\ (0 replacements on both files).
- Builds end-to-end on Android NDK 27.0.12077973, CMake 3.22.1, for \rm64-v8a\ and \x86_64\ — produces \libdasher.so\ consumed by the Dasher-Android JNI layer.

Frontend tracking this submodule pin: dasher-project/Dasher-Android (Phase 0 scaffold).