### PR TITLE
Fix editOutput crash: reset cursorPos when editBuffer is cleared

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -410,6 +410,9 @@ struct dasher_ctx {
             return static_cast<unsigned int>(m_owner->cursorPos);
         }
         void editOutput(const std::string& strText, Dasher::CDasherNode* pCause) override {
+            if (m_owner->cursorPos > m_owner->editBuffer.size()) {
+                m_owner->cursorPos = m_owner->editBuffer.size();
+            }
             m_owner->editBuffer.insert(m_owner->cursorPos, strText);
             m_owner->cursorPos += strText.size();
             if (m_owner->outputCb && !strText.empty()) m_owner->outputCb(0, strText.c_str(), m_owner->outputCbUserData);
@@ -643,11 +646,13 @@ DASHER_API const char* dasher_get_output_text(dasher_ctx* ctx) {
 DASHER_API void dasher_reset_output_text(dasher_ctx* ctx) {
     if (!ctx) return;
     ctx->editBuffer.clear();
+    ctx->cursorPos = 0;
 }
 
 DASHER_API void dasher_reset(dasher_ctx* ctx) {
     if (!ctx || !ctx->intf) return;
     ctx->editBuffer.clear();
+    ctx->cursorPos = 0;
     ctx->intf->SetOffset(0, true);
 }
 
@@ -660,6 +665,7 @@ DASHER_API const char* dasher_get_alphabet_id(dasher_ctx* ctx) {
 DASHER_API void dasher_set_alphabet_id(dasher_ctx* ctx, const char* alphabet_id) {
     if (!ctx || !ctx->intf || !alphabet_id) return;
     ctx->editBuffer.clear();
+    ctx->cursorPos = 0;
     if (!ctx->realized) {
         ctx->pendingAlphabet = alphabet_id;
         return;


### PR DESCRIPTION
## Problem

DasherApp build 32 on TestFlight hit 3 crashes (out of 4 total) with the identical stack trace:

```
std::__throw_out_of_range
  → std::string::insert(pos, str, len)
  → dasher_ctx::Interface::editOutput(text, node)
  → CSymbolNode::Do()
  → CDasherModel::OutputTo()
  → CDasherModel::RenderToView()
  → CDasherInterfaceBase::NewFrame()
  → dasher_frame
```

All on iPhone 14,2 / iOS 26.5. User comments: "loaded a text file… started writing crashed", "Not sure", "turbo mode… driving through text on crash".

## Root cause

Three CAPI functions clear `editBuffer` but don't reset `cursorPos`:

| Function | Clears `editBuffer`? | Resets `cursorPos`? |
|---|---|---|
| `dasher_reset_output_text()` | ✅ | ❌ — **bug** |
| `dasher_reset()` | ✅ | ❌ — **bug** |
| `dasher_set_alphabet_id()` | ✅ | ❌ — **bug** |

After any of these, `cursorPos` can be non-zero (e.g. 500) while `editBuffer.size()` is 0. The next `editOutput()` call does:

```cpp
editBuffer.insert(cursorPos, strText);  // cursorPos=500, size=0 → std::out_of_range
```

→ uncaught C++ exception → `__cxa_throw` → `abort()` → SIGABRT.

## Fix

**Root cause** — reset `cursorPos = 0` in all three buffer-clear functions:
- `dasher_reset_output_text()` 
- `dasher_reset()`
- `dasher_set_alphabet_id()`

**Defensive** — clamp `cursorPos` to `editBuffer.size()` at the top of `editOutput()` so even an unknown future caller can't trigger the same exception.

6 insertions, 0 deletions. No API changes.

## Verification

- clang-format: clean
- TestFlight crash reports (DasherApp #6778978722, build 32): all three `editOutput` crashes should stop after this fix lands in a new build.

<!-- DCO -->
