### PR TITLE
Fix appearance model: late-seed dark companion after Realize

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -541,6 +541,17 @@ int effectiveAppearanceValue(const dasher_ctx* ctx) {
 // source of truth, so this can never clobber the user's explicit choice.
 void resolveAppearance(dasher_ctx* ctx) {
     if (!ctx || !ctx->intf) return;
+
+    // Late seed: ensureAppearanceInitialised may have run before Realize,
+    // when ColorIO wasn't available and the companion lookup failed.
+    // Retry now — once ColorIO exists, the lookup succeeds and fills the gap.
+    if (ctx->darkPalette.empty() && !ctx->lightPalette.empty()) {
+        if (auto* colorIO = ctx->intf->GetColorIO()) {
+            if (const Dasher::ColorPalette* comp = companionLookup(colorIO, ctx->lightPalette))
+                ctx->darkPalette = comp->PaletteName;
+        }
+    }
+
     int eff = effectiveAppearanceValue(ctx);
     std::string target = (eff == 1) ? ctx->lightPalette : ctx->darkPalette;
     if (target.empty()) target = (eff == 1) ? ctx->darkPalette : ctx->lightPalette; // other side


### PR DESCRIPTION
## Problem

System appearance changes don't flip the palette — the canvas stays on the same colour scheme regardless of iOS light/dark setting.

## Root cause

`ensureAppearanceInitialised` seeds `darkPalette` by looking up the current palette's companion. But frontends call `dasher_set_system_appearance` from their `.onAppear` handler, which fires **before Realize()** — before ColorIO is populated. At that point the companion lookup fails, `darkPalette` stays empty, and once `appearanceLoaded = true` the seed is never retried.

`resolveAppearance` then picks an empty `darkPalette`, falls back to `lightPalette` (or also empty), and returns without doing anything.

Timeline:


## Fix

Add a late-seed check in `resolveAppearance`: if `darkPalette` is empty but `lightPalette` is set and ColorIO is now available, retry the companion lookup. Runs on every call, so once Realize completes and the next system/mode change arrives, the companion is found.

11 insertions, no deletions. No API change.

<!-- DCO -->