### PR TITLE
Fix crash: clamp model offset in ctrlOffsetAfterMove + findBefore/findAfter

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -73,6 +73,7 @@ bool isSep(char c, const char* seps) {
 
 // Forward search: skip non-separators, then skip separators
 size_t findAfter(const std::string& s, size_t pos, const char* seps) {
+    if (pos > s.size()) pos = s.size();
     size_t p = pos;
     while (p < s.size() && !isSep(s[p], seps)) {
         p = nextChar(s, p);
@@ -85,6 +86,7 @@ size_t findAfter(const std::string& s, size_t pos, const char* seps) {
 
 // Backward search: skip separators, then skip non-separators
 size_t findBefore(const std::string& s, size_t pos, const char* seps) {
+    if (pos >= s.size()) pos = s.size() > 0 ? s.size() - 1 : 0;
     size_t p = pos;
     while (p > 0 && isSep(s[p], seps)) {
         p = prevChar(s, p);
@@ -396,7 +398,12 @@ struct dasher_ctx {
 
         unsigned int ctrlOffsetAfterMove(unsigned int offsetBefore, bool bForwards,
                                          Dasher::EditDistance dist) override {
-            size_t start = offsetBefore, end = offsetBefore;
+            // offsetBefore is the model's node offset, which can exceed editBuffer.size()
+            // because control nodes have offsets but produce no edit buffer characters.
+            // Clamp to buffer bounds before using as an index.
+            size_t bufLen = m_owner->editBuffer.size();
+            size_t clamped = std::min(static_cast<size_t>(offsetBefore), bufLen);
+            size_t start = clamped, end = clamped;
             getRange(m_owner->editBuffer, bForwards, dist, start, end);
             return static_cast<unsigned int>(bForwards ? end : start);
         }


### PR DESCRIPTION
## Problem

Crash on DasherMac (macOS 26.5 hardened libc++): `string::operator[]` assertion fires when expanding a control node that tries to calculate a delete offset.

## Stack trace

```
frame #4: string::operator[](this="aaaaaaaaaa.", __pos=75)     ← 11-char string, index 75
frame #5: findBefore(pos=75)                                    at CAPI.cpp:89
frame #6: getRange(buf="aaaaaaaaaa.", ...)                      at CAPI.cpp:134
frame #7: ctrlOffsetAfterMove(offsetBefore=76)                  at CAPI.cpp:400
frame #8: DeleteAction::calculateNewOffset(offsetBefore=75)     at ControlManager.cpp:193
frame #9: NodeTemplate::calculateNewOffset(offsetBefore=75)     at ControlManager.cpp:67
frame #10: CContNode::PopulateChildren()                        at ControlManager.cpp:94
frame #11: CDasherModel::ExpandNode()
```

## Root cause

`ctrlOffsetAfterMove` uses the model's node offset (75) directly as an index into the edit buffer (11 chars). These diverge because **control nodes have offsets in the model tree but produce no edit buffer characters** — so the model offset can grow far beyond the buffer length.

## Fix

Three layers of defence:

1. **`ctrlOffsetAfterMove`**: clamp `offsetBefore` to `editBuffer.size()` before passing to `getRange`
2. **`findBefore`**: clamp `pos` to `s.size()-1` at entry (the function accesses `s[pos]`)
3. **`findAfter`**: clamp `pos` to `s.size()` at entry (same defensive pattern)

8 insertions, 1 deletion. No API changes.

<!-- DCO -->
