### PR TITLE
governance: add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner
+* @willwade
+
+# Additional maintainers per governance README
+# @prlw1 @ipomoena @PapeCoding @gavinhenderson @cagdasgerede


### PR DESCRIPTION
Adds CODEOWNERS with @willwade as default owner, matching the other v6 frontends (Dasher-Apple, Dasher-Windows, Dasher-Android).