### PR TITLE
docs: correct C API arity, opcode table, and parameter/test counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All translatable strings live in one place: `settings_manifest.json`. The engine
 
 ```bash
 python3 Scripts/extract_strings.py
-# → Strings/strings_en.json (219 flat key-value pairs)
+# → Strings/strings_en.json (201 flat key-value pairs)
 ```
 
 This produces a simple JSON file that translators edit. Keys use the C++ enum constant names:
@@ -172,7 +172,7 @@ The C API lives in `src/dasher.h` (public header) and `src/CAPI.cpp` (implementa
 ```c
 #include "dasher.h"
 
-dasher_ctx* ctx = dasher_create("/path/to/DasherCore/Data");
+dasher_ctx* ctx = dasher_create("/path/to/DasherCore/Data", NULL, NULL);
 dasher_set_screen_size(ctx, 800, 600);
 
 while (running) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 This document describes the internal architecture of DasherCore — the
 engine, not the frontends. It targets developers who need to understand
 the code flow before making changes. For the public C API contract, see
-`src/dasher.h`. For the cleanup plan, see `TIER2-3-PLAN.md`.
+`src/dasher.h`.
 
 
 ## Component overview
@@ -56,7 +56,7 @@ the code flow before making changes. For the public C API contract, see
 | `CDasherInput` | Abstract input device. C API provides `PointerInput` (mouse/touch). | `DasherInput.h` |
 | `CInputFilter` | Input interpretation strategy (14 registered: Normal Control, Click Mode, One/Button/Two-Button/Two-Push Dynamic, etc.). | `InputFilter.h` |
 | `CNodeCreationManager` | Creates and manages the node tree. Owns the AlphabetManager, ConversionManager, ControlManager, and Trainer. | `NodeCreationManager.h` |
-| `CLanguageModel` | Probability model for predicting next symbol. 5 registered: PPM, Word, Mixture, CTW, Mandarin (PPMPY). | `LanguageModel.h` |
+| `CLanguageModel` | Probability model for predicting next symbol. 4 registered in LMRegistry: PPM, Word, Mixture, CTW. Mandarin (PPMPY) is created directly by `CMandarinAlphMgr`, not via the registry. | `LanguageModel.h` |
 | `CSettingsStore` | Parameter storage. Backed by `XmlSettingsStore` for persistence. | `SettingsStore.h` |
 
 
@@ -175,18 +175,18 @@ dasher_frame(ctx, time_ms, &cmds, &cmd_count, &strs, &str_count)
 ### Draw command format
 
 Each frame produces an array of `int` commands. Commands are
-opcode-driven, 6 ints each (except text commands which are variable):
+opcode-driven, 6 ints each (the text command stores only a string index; the string itself is returned separately):
 
 ```
 [opcode] [arg1] [arg2] [arg3] [arg4] [arg5]
 
-Opcode 0: Clear screen     [argb color] [alpha] [0] [0] [0]
-Opcode 1: Circle           [center_x] [center_y] [radius] [fill_argb] [outline_argb]
-Opcode 2: Rectangle (outline-only) [x1] [y1] [x2] [y2] [color]
-Opcode 3: Rectangle (filled) [x1] [y1] [x2] [y2] [fill_color]
-Opcode 4: Polygon          [count] [points_offset] [fill] [outline] [width]
-Opcode 5: Text             [string_index] [x] [y] [font_size] [color]
-Opcode 6: Polyline         [width] [color] [0] [0] [0]
+Opcode 0: Clear screen     [0] [0] [0] [0] [argb background]
+Opcode 1: Circle           [center_x] [center_y] [radius] [1 filled / 0 outline] [argb]
+Opcode 2: Line segment     [x1] [y1] [x2] [y2] [argb]
+Opcode 3: Rectangle (outline) [x1] [y1] [x2] [y2] [argb]
+Opcode 4: Rectangle (filled) [x1] [y1] [x2] [y2] [argb]
+Opcode 5: Text             [x] [y] [font_size] [string_index] [argb]
+Opcode 6: Polyline width   [width] [0] [0] [0] [0]
 ```
 
 The frontend interprets these commands and draws to its native canvas.
@@ -237,7 +237,7 @@ CWD leak fixed in Tier 1 #5. It now writes to `{userDir}/` via
 
 Parameters are defined in `settings_manifest.json` (the canonical
 source). A Python codegen (`Scripts/generate_parameters.py`) generates
-`Parameters.h` (enum) and `Parameters.cpp` (default values + metadata).
+`Parameters.cpp` (default values + metadata). The `Parameters.h` enum is hand-maintained.
 
 Three parameter kinds:
 - **BP_** (Bool Parameters): `BP_LM_ADAPTIVE`, `BP_CONTROL_MODE`, etc.
@@ -288,7 +288,7 @@ only threading protection, and it's a safety net, not a design feature.
 
 ## Test architecture
 
-31 test executables, all using doctest (vendored in `Thirdparty/doctest/`).
+32 test executables, all using doctest (vendored in `Thirdparty/doctest/`).
 Shared helpers in `tests/test_common.h`:
 
 - `create_isolated_context()` / `ScopedContext` — per-test temp dir + context

--- a/docs/C_API.md
+++ b/docs/C_API.md
@@ -64,7 +64,7 @@ cmake --build .
 |--------|------|--------|
 | `DasherCore` | Static library | Core C++ engine |
 | `dasher` | Shared library | C API (`src/CAPI.cpp`) |
-| `dasher_test` | Executable | Unit tests |
+| `dasher_*_tests` | Executables | Unit tests (one executable per test file, e.g. `dasher_capi_tests`) |
 
 ### Code Generation
 
@@ -337,12 +337,12 @@ void dasher_set_speed_percent(dasher_ctx* ctx, int percent);
 
 ## Parameters
 
-DasherCore has a self-describing parameter schema with 86 parameters across three types:
+DasherCore has a self-describing parameter schema with 99 parameters across three types:
 
 | Type | Prefix | Count | Accessors |
 |------|--------|-------|-----------|
-| Boolean | `BP_*` | 27 | `dasher_get/set_bool_parameter` |
-| Long | `LP_*` | 46 | `dasher_get/set_long_parameter` |
+| Boolean | `BP_*` | 30 | `dasher_get/set_bool_parameter` |
+| Long | `LP_*` | 56 | `dasher_get/set_long_parameter` |
 | String | `SP_*` | 13 | `dasher_get/set_string_parameter` |
 
 ### Generic Parameter Access


### PR DESCRIPTION
Documentation-only accuracy fixes verified against the current code:

- README: `dasher_create` shown with its real 3 args; `extract_strings.py` output count corrected to 201 keys.
- docs/ARCHITECTURE.md: draw-command opcode table rewritten to match `CommandScreen` in src/CAPI.cpp; text command is fixed 6-int (string by index); `generate_parameters.py` emits only Parameters.cpp (the enum header is hand-maintained); 32 test executables; LMRegistry registers 4 models (Mandarin is created by CMandarinAlphMgr); removed a dead link to a non-existent TIER2-3-PLAN.md.
- docs/C_API.md: 99 parameters (30 BP_, 56 LP_, 13 SP_); test target naming corrected to per-file executables.

No code changes.