### PR TITLE
fix: remove leftover [RATE] debug fprintfs from CAPI

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -475,7 +475,6 @@ struct dasher_ctx {
             m_owner->cursorPos += strText.size();
             if (m_owner->outputCb && !strText.empty()) m_owner->outputCb(0, strText.c_str(), m_owner->outputCbUserData);
             m_owner->rateTimestamps.push_back(std::chrono::steady_clock::now());
-            fprintf(stderr, "[RATE] editOutput push: size=%zu\n", m_owner->rateTimestamps.size());
             CDashIntfScreenMsgs::editOutput(strText, pCause);
         }
         void editDelete(const std::string& strText, Dasher::CDasherNode* pCause) override {
@@ -1839,7 +1838,6 @@ DASHER_API double dasher_get_cps(dasher_ctx* ctx) {
     double elapsed = std::chrono::duration<double>(now - ctx->rateTimestamps.front()).count();
     if (elapsed < 1.0) elapsed = 1.0;
     double cps = static_cast<double>(ctx->rateTimestamps.size()) / elapsed;
-    fprintf(stderr, "[RATE] getCps: size=%zu elapsed=%.1f cps=%.2f\n", ctx->rateTimestamps.size(), elapsed, cps);
     return cps;
 }
 


### PR DESCRIPTION
Two debug `fprintf(stderr, ...)` statements were left in the CPS/WPM rate-tracking code (added in #42 / v0.1.8):

1. `editOutput` (line 478): fired on **every character push** — one fprintf per keystroke
2. `getCps` (line 1842): fired on **every CPS read**

Both spam stderr in production builds. Removed both lines; no logic change.

Found by @owenpkent in [Dasher-GTK #35 comment](https://github.com/dasher-project/Dasher-GTK/issues/35).