### PR TITLE
fix(capi): cube node shape rendered black canvas (issue #47)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ if(BUILD_CAPI)
         dasher_add_test(dasher_circle_geometry_tests test_circle_geometry.cpp)
         # Internal: links DasherCore directly to drive CircleTo/IsSpaceAroundNode.
         dasher_add_test_internal(dasher_circle_view_internal_tests test_circle_view_internal.cpp)
+        dasher_add_test(dasher_cube_geometry_tests test_cube_geometry.cpp)
         dasher_add_test(dasher_input_filter_tests test_input_filters.cpp)
         dasher_add_test(dasher_xml_error_path_tests test_xml_error_paths.cpp)
 

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -268,6 +268,42 @@ class CommandScreen final : public Dasher::CDasherScreen {
         }
     }
 
+    // ── Cube mode (Options::CUBE) ───────────────────────────────────────────
+    // The flat command buffer has no 3D backend, so cube mode renders as flat
+    // shaded rectangles: one filled rect (opcode 4) per cube face, plus an
+    // outline (opcode 3) when requested. Without these overrides the whole cube
+    // path is silently dropped (the base-class methods are no-ops), which left
+    // the canvas black — see issue #47.
+    void DrawCube(float posX, float posY, float sizeX, float sizeY, Dasher::CubeDepthLevel, Dasher::CubeDepthLevel,
+                  const Dasher::ColorPalette::Color& color, const Dasher::ColorPalette::Color& outlineColor,
+                  int iThickness) override {
+        const int x1 = static_cast<int>(posX - sizeX / 2.0f);
+        const int y1 = static_cast<int>(posY - sizeY / 2.0f);
+        const int x2 = static_cast<int>(posX + sizeX / 2.0f);
+        const int y2 = static_cast<int>(posY + sizeY / 2.0f);
+        if (!color.isFullyTransparent()) push(4, x1, y1, x2, y2, colorToARGB(color));
+        if (iThickness > 0 && !outlineColor.isFullyTransparent()) push(3, x1, y1, x2, y2, colorToARGB(outlineColor));
+    }
+
+    void Draw3DLabel(Label* label, Dasher::screenint x, Dasher::screenint y, Dasher::screenint,
+                     Dasher::Options::ScreenOrientations, Dasher::myint, Dasher::myint, unsigned int iFontSize,
+                     const Dasher::ColorPalette::Color& color) override {
+        // Cube-mode labels reach the screen via Draw3DLabel rather than DrawString;
+        // emit the same opcode-5 text command. The 3D extrusion is lost, but the
+        // label is positioned/coloured identically.
+        DrawString(label, x, y, iFontSize, color);
+    }
+
+    void DrawProjectedRectangle(Dasher::screenint posX, Dasher::screenint posY, Dasher::screenint sizeX,
+                                Dasher::screenint sizeY, const Dasher::ColorPalette::Color& color) override {
+        // The cube-mode crosshair bar. Emit it as a filled rectangle.
+        const int x1 = static_cast<int>(posX - sizeX / 2);
+        const int y1 = static_cast<int>(posY - sizeY / 2);
+        const int x2 = static_cast<int>(posX + sizeX / 2);
+        const int y2 = static_cast<int>(posY + sizeY / 2);
+        if (!color.isFullyTransparent()) push(4, x1, y1, x2, y2, colorToARGB(color));
+    }
+
     void Display() override {}
     bool IsPointVisible(Dasher::screenint x, Dasher::screenint y) override {
         return x >= 0 && y >= 0 && x < GetWidth() && y < GetHeight();

--- a/src/DasherCore/DasherScreen.h
+++ b/src/DasherCore/DasherScreen.h
@@ -96,13 +96,21 @@ class Dasher::CDasherScreen {
                             const ColorPalette::Color& color) = 0;
 
     // Cubes and 3D labels that are drawn in Options::CUBE mode, meant for a 3D rendering
+    // backend. The default implementations are all no-ops, so a plain 2D screen (such as
+    // the C API CommandScreen) must override DrawCube / Draw3DLabel / DrawProjectedRectangle
+    // to make cube mode render anything at all. FinishRender3D stays a no-op for 2D screens
+    // (there is no 3D compositing pass to flush).
     virtual void Draw3DLabel(Label* label, screenint x, screenint y, screenint textInset,
                              Options::ScreenOrientations orientation, myint extrusionLevel, myint groupRecursionDepth,
                              unsigned int iFontSize, const ColorPalette::Color& color) {}
     virtual void DrawCube(float posX, float posY, float sizeX, float sizeY, CubeDepthLevel nodeDepth,
                           CubeDepthLevel parentDepth, const ColorPalette::Color& color,
                           const ColorPalette::Color& outlineColor, int iThickness) {}
-    virtual void DrawProjectedRectangle(screenint posX, screenint posY, screenint sizeX, screenint sizeY) {}
+    // A rectangle projected through the 3D scene (the cube-mode crosshair bar). The colour
+    // is supplied by the caller (the view, via its palette) because CDasherScreen itself has
+    // no palette access.
+    virtual void DrawProjectedRectangle(screenint posX, screenint posY, screenint sizeX, screenint sizeY,
+                                        const ColorPalette::Color& color) {}
     virtual void FinishRender3D(myint originX, myint originY, myint originExtrusionLevel) {}
 
     /// Draw a filled rectangle

--- a/src/DasherCore/DasherViewSquare.cpp
+++ b/src/DasherCore/DasherViewSquare.cpp
@@ -125,7 +125,7 @@ CDasherNode* CDasherViewSquare::Render(CDasherNode* pRoot, myint iRootMin, myint
         screenint sizeX = 7, sizeY = static_cast<screenint>(static_cast<float>(Screen()->GetHeight()) * 1.05f);
         if (GetOrientation() == Options::TopToBottom || GetOrientation() == Options::BottomToTop)
             std::swap(sizeX, sizeY);
-        Screen()->DrawProjectedRectangle(originX, originY, sizeX, sizeY);
+        Screen()->DrawProjectedRectangle(originX, originY, sizeX, sizeY, GetNamedColor(NamedColor::crosshair));
 
         // Print 3DText
         for (geometry_3DText& text : m_Delayed3DTexts) {

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -86,8 +86,15 @@ DASHER_API void dasher_key_event(dasher_ctx* ctx, int key, int pressed);
 //   3: Rectangle outline     — a=x1, b=y1, c=x2, d=y2, argb
 //   4: Rectangle filled      — a=x1, b=y1, c=x2, d=y2, argb
 //   5: Text                  — a=x, b=y, c=fontSize, d=stringIndex, argb
+//   6: Set line width        — a=lineWidth (applies to subsequent opcode 2 lines)
 //
 // For opcode 5, d is an index into the strings array.
+//
+// LP_SHAPE_TYPE == CUBE (6) renders through the same opcode-3/4/5 commands:
+// each cube face is an opcode-4 filled rectangle (with an opcode-3 outline when
+// the node has one), the crosshair bar is an opcode-4 rectangle, and cube-mode
+// labels are opcode-5 text. The flat buffer carries no 3D extrusion, so cube
+// mode looks like flat rectangles over this API.
 //
 // argb format: (alpha << 24) | (red << 16) | (green << 8) | blue
 DASHER_API void dasher_frame(dasher_ctx* ctx, int64_t time_ms, int** out_commands, int* out_command_count,

--- a/tests/test_cube_geometry.cpp
+++ b/tests/test_cube_geometry.cpp
@@ -1,0 +1,96 @@
+// test_cube_geometry.cpp
+//
+// REGRESSION TESTS for the cube node-shape (LP_SHAPE_TYPE == CUBE, 6) via the
+// C API command buffer.
+//
+// Bug (issue #47): CUBE mode rendered a black canvas because CDasherViewSquare
+// drives cube drawing through Screen()->DrawCube / Draw3DLabel /
+// DrawProjectedRectangle / FinishRender3D, and the C API's CommandScreen
+// (CAPI.cpp) never overrode them — so zero draw commands were emitted for cube
+// nodes. Only the clear-screen (opcode 0) fired.
+//
+// These tests confirm cube mode now emits real geometry (filled-rect and text
+// commands) instead of just the background clear.
+
+#include "test_common.h"
+
+namespace {
+
+const int LP_SHAPE_TYPE_CUBE = 6; // Options::CUBE
+
+// Runs `frames` frames in cube mode and returns the count of the given opcode.
+int count_opcode(dasher_ctx* ctx, int frames, int opcode) {
+    int seen = 0;
+    for (int i = 0; i < frames; ++i) {
+        int* cmds = nullptr;
+        int cc = 0;
+        char** strs = nullptr;
+        int sc = 0;
+        dasher_frame(ctx, 1000 + i * 16, &cmds, &cc, &strs, &sc);
+        for (int j = 0; j + 5 < cc; j += 6) {
+            if (cmds[j] == opcode) ++seen;
+        }
+    }
+    return seen;
+}
+
+} // namespace
+
+TEST_CASE("cube/first frame emits node geometry, not just clear-screen") {
+    ScopedContext ctx(800, 600);
+    const int lp_shape = dasher_find_parameter_key("LP_SHAPE_TYPE");
+    REQUIRE(lp_shape > 0);
+    dasher_set_long_parameter(ctx, lp_shape, LP_SHAPE_TYPE_CUBE);
+    REQUIRE(dasher_get_long_parameter(ctx, lp_shape) == LP_SHAPE_TYPE_CUBE);
+
+    int* cmds = nullptr;
+    int cc = 0;
+    char** strs = nullptr;
+    int sc = 0;
+    dasher_frame(ctx, 1000, &cmds, &cc, &strs, &sc);
+
+    // Before the fix, only the clear-screen (opcode 0) plus a single decorative
+    // rect/line were emitted — cube node faces never reached the buffer.
+    // The root node alone produces several filled rects once DrawCube translates
+    // to opcode 4.
+    CHECK(count_opcode(ctx, 3, 4) > 3); // cube node faces (opcode 4)
+
+    dasher_set_long_parameter(ctx, lp_shape, 1); // restore
+}
+
+TEST_CASE("cube/forward driving draws nodes and labels") {
+    ScopedContext ctx(800, 600);
+    const int lp_shape = dasher_find_parameter_key("LP_SHAPE_TYPE");
+    REQUIRE(lp_shape > 0);
+    dasher_set_long_parameter(ctx, lp_shape, LP_SHAPE_TYPE_CUBE);
+
+    dasher_set_speed_percent(ctx, 250);
+    dasher_mouse_move(ctx, 720.0f, 300.0f);
+    dasher_mouse_down(ctx);
+
+    const int rects = count_opcode(ctx, 30, 4);  // filled rectangles (cube faces)
+    const int labels = count_opcode(ctx, 30, 5); // text labels (Draw3DLabel)
+
+    dasher_mouse_up(ctx);
+
+    // Buggy code: ~1 decorative rect/frame and ZERO labels. Fixed code draws a
+    // cube face per visible node plus a label per labelled node.
+    CHECK(rects > 50);
+    CHECK(labels > 5);
+
+    dasher_set_long_parameter(ctx, lp_shape, 1); // restore
+}
+
+TEST_CASE("cube/switching into and out of cube mode is stable") {
+    ScopedContext ctx(800, 600);
+    const int lp_shape = dasher_find_parameter_key("LP_SHAPE_TYPE");
+    REQUIRE(lp_shape > 0);
+
+    dasher_set_long_parameter(ctx, lp_shape, LP_SHAPE_TYPE_CUBE);
+    run_frames(ctx, 5);
+    CHECK(dasher_get_long_parameter(ctx, lp_shape) == 6);
+
+    dasher_set_long_parameter(ctx, lp_shape, 1);
+    run_frames(ctx, 5);
+    CHECK(dasher_get_long_parameter(ctx, lp_shape) == 1);
+}


### PR DESCRIPTION
## Problem

When `LP_SHAPE_TYPE == CUBE` (6), the canvas went black via the C API — only the background clear-screen fired, no nodes visible. The app didn't crash.

## Root cause
`CDasherViewSquare` in cube mode drives rendering through `Screen()->DrawCube` (per node face), `Screen()->Draw3DLabel` (text), `Screen()->DrawProjectedRectangle` (crosshair bar), and `Screen()->FinishRender3D` (composite). All four are virtual on `CDasherScreen` with **empty no-op defaults** (`DasherScreen.h:98-106`).

The C API's `CommandScreen` (CAPI.cpp) — the screen adapter that translates DasherCore rendering into the flat `int[]` command buffer consumed by every frontend — **never overrode them**. So zero draw commands were emitted for cube nodes. Confirmed by opcode histogram in cube mode: `0:10 2:10 4:10 6:10` per 10 frames (just clear-screen + one decorative rect/line), with **zero labels**.

Same class of bug as the circle crashes (#46) — a rendering mode the C-API path was never tested with.

## Fix (Option A from the issue, localized to the C-API screen)
Override the 3D hooks in `CommandScreen` to translate cube drawing into the existing flat command format (no new opcodes):
- `DrawCube` → opcode **4** (filled front-face rect) + opcode **3** (outline when requested)
- `Draw3DLabel` → opcode **5** (text), reusing `DrawString`
- `DrawProjectedRectangle` → opcode **4** (the cube-mode crosshair bar)
- `FinishRender3D` → keeps the base no-op (nothing to composite in 2D)

The flat buffer has no 3D backend, so cube mode renders as flat shaded rectangles over this API (the issue explicitly accepts losing the 3D extrusion: "simpler but loses the cube visual").

### One clean interface change
`DrawProjectedRectangle` previously took no colour, and `CDasherScreen` has no palette access (only the view has). I added a `color` argument supplied by the view from its palette. No in-tree overrides existed and the only caller is the cube path (verified by full-repo grep + clean build of all targets). Out-of-tree 3D screens that override it need a one-line update to accept the colour.

## Why not Option B (capability check + flat fallback)?
Both approaches produce flat rectangles via the command buffer; the only real difference is where the fallback lives. Option A is localized to `CAPI.cpp` (no core view logic change), reuses the cube path's blanking/margin behaviour, and keeps the interface improvement (passing the crosshair colour).

## Docs
`dasher.h`: documented opcode 6 (set line width — already emitted by `Polyline` but undocumented) and noted that cube mode maps to opcode 3/4/5.

## Test
`test_cube_geometry.cpp` — drives cube mode via the C API and asserts that filled rects (cube faces) and text labels are emitted. **Fails on unpatched code** (0 labels, ~1 decorative rect/frame) and passes after.

## Verification
- clang-format clean (`--Werror` dry-run)
- Debug build: cube/circle/view/draw tests pass
- Release build: cube/circle/draw_snapshot tests pass
- `dasher_draw_snapshot_tests` (golden) unaffected — default-shape rendering unchanged