### PR TITLE
feat(capi): Strand 2 custom-rendering API (RFC 0013)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ if(BUILD_CAPI)
         # Internal: links DasherCore directly to drive CircleTo/IsSpaceAroundNode.
         dasher_add_test_internal(dasher_circle_view_internal_tests test_circle_view_internal.cpp)
         dasher_add_test(dasher_cube_geometry_tests test_cube_geometry.cpp)
+        dasher_add_test(dasher_strand2_nodes_tests test_strand2_nodes.cpp)
         dasher_add_test(dasher_input_filter_tests test_input_filters.cpp)
         dasher_add_test(dasher_xml_error_path_tests test_xml_error_paths.cpp)
 

--- a/docs/C_API.md
+++ b/docs/C_API.md
@@ -234,8 +234,97 @@ int dasher_color_rgb(int red, int green, int blue);              // Create opaqu
 int dasher_color_get_alpha(int argb);                            // Extract alpha
 int dasher_color_get_red(int argb);                              // Extract red
 int dasher_color_get_green(int argb);                            // Extract green
-int dasher_color_get_blue(int argb);                             // Extract blue
+int dasher_color_get_blue(int argb);                            // Extract blue
 ```
+
+## Custom Rendering — Strand 2 (RFC 0013)
+
+The `int[]` command buffer from `dasher_frame()` (Strand 1) is 2D painter's algorithm — no depth buffer, no compositing. It can't represent 3D extruded cubes, VR/spatial layouts, or fully custom visualisations. **Strand 2** is the alternative: query the visible node tree each frame and render it yourself with your own graphics API.
+
+The two strands coexist. A frontend can use Strand 1 for most rendering and drop into Strand 2 for specific features (e.g. render cube mode as real 3D from the node tree), or render everything from scratch.
+
+### Enabling capture
+
+Node capture is **off by default** — Strand 1-only frontends pay zero overhead. Enable it once at setup:
+
+```c
+dasher_set_visible_nodes_enabled(ctx, 1);
+```
+
+After this, each `dasher_frame()` records the nodes it draws; `dasher_get_visible_nodes()` returns them.
+
+### `dasher_get_visible_nodes`
+
+```c
+typedef struct dasher_node_info {
+    int struct_size;            // caller sets to sizeof(dasher_node_info) before the call
+    long long dasher_y1;        // node's Dasher-Y range
+    long long dasher_y2;
+    int symbol;                 // alphabet symbol index (-1 for group/control nodes)
+    int has_children;           // 1 if this node has children
+    int depth;                  // tree depth from the rendered root (0 = root)
+    int is_game_node;           // 1 if on the game-mode path
+    int screen_x1, screen_y1;   // node's clipped screen bounds
+    int screen_x2, screen_y2;
+    int fill_argb;              // node fill colour (from active palette)
+    int outline_argb;           // node outline colour
+    int label_index;            // index into out_strings (-1 if no label)
+} dasher_node_info;
+
+// Returns the number of visible nodes (may exceed max_nodes — grow the buffer
+// and re-query if so). Nodes are depth-first (parent before children).
+// out_strings / out_string_count hold label text; label_index indexes into it.
+// out_nodes and out_strings are engine-owned, valid until the next
+// dasher_frame() or dasher_get_visible_nodes() call.
+// Returns -1 if capture is disabled, the engine isn't realised, or the caller's
+// struct_size is smaller than this engine's struct.
+int dasher_get_visible_nodes(dasher_ctx* ctx, dasher_node_info* out_nodes, int max_nodes,
+                             char*** out_strings, int* out_string_count);
+```
+
+The captured node set matches **exactly** what the Strand 1 command buffer draws for the same frame (Strand 1/Strand 2 parity), so a frontend can mix strands without drift. `screen_x1..y2` use the same clip formula as the opcode-4 filled-rectangle draw. `depth` is the source for cube extrusion (deeper nodes recede); `symbol`/`label_index` identify what each node represents.
+
+### `dasher_get_viewport`
+
+```c
+typedef struct dasher_viewport {
+    int struct_size;            // caller sets to sizeof(dasher_viewport) before the call
+    long long crosshair_x;      // crosshair Dasher X (fixed at the origin)
+    long long crosshair_y;      // crosshair Dasher Y
+    long long visible_min_y;    // visible Dasher-Y range
+    long long visible_max_y;
+    int screen_width;           // canvas size from dasher_set_screen_size
+    int screen_height;
+} dasher_viewport;
+
+int dasher_get_viewport(dasher_ctx* ctx, dasher_viewport* out);  // 0 on success, -1 on error
+```
+
+### Rendering example (Strand 2)
+
+```c
+dasher_set_visible_nodes_enabled(ctx, 1);
+
+// each frame:
+dasher_frame(ctx, time_ms, &cmds, &cc, &strs, &sc);  // still call it — it advances the engine
+
+dasher_node_info nodes[256];
+for (int i = 0; i < 256; ++i) nodes[i].struct_size = sizeof(dasher_node_info);
+char** labels = NULL;
+int label_count = 0;
+int n = dasher_get_visible_nodes(ctx, nodes, 256, &labels, &label_count);
+if (n > 256) { /* grew past the buffer — reallocate and re-query */ }
+
+for (int i = 0; i < n && i < 256; ++i) {
+    dasher_node_info nd = nodes[i];
+    // Render however you like: flat rect, 3D cube extruded by nd.depth, sphere…
+    if (nd.label_index >= 0) draw_label(labels[nd.label_index], nd.screen_x1, nd.screen_y1);
+    draw_node(nd.screen_x1, nd.screen_y1, nd.screen_x2, nd.screen_y2,
+              nd.fill_argb, nd.outline_argb);
+}
+```
+
+For a 3D cube frontend, render the same nodes in two passes (flat layout first, then cubes composited on top using `depth` for the extrusion), or render everything in 3D from the start. `LP_SHAPE_TYPE` (read via `dasher_get_long_parameter`) is a hint the frontend can honour or ignore — shape and depth become frontend concerns, not engine concerns.
 
 ## Output Text
 

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -1880,26 +1880,26 @@ DASHER_API int dasher_get_visible_nodes(dasher_ctx* ctx, dasher_node_info* out_n
             out.struct_size = v1_size;
             out.dasher_y1 = static_cast<long long>(n.dasher_y1);
             out.dasher_y2 = static_cast<long long>(n.dasher_y2);
-            // GetAlphSymbol() throws on the base class (only CSymbolNode
-            // overrides it), so gate it on IsSymbolNode(). Group/control/
-            // conversion nodes report -1.
-            out.symbol = (n.node && n.node->IsSymbolNode()) ? n.node->GetAlphSymbol() : -1;
-            out.has_children = n.node && n.node->ChildCount() > 0 ? 1 : 0;
+            // All node-derived values were resolved during Render() and stored
+            // in the snapshot — no CDasherNode* is dereferenced here, so the
+            // model is free to mutate/free nodes between the frame and this
+            // query. (Previously this lazily dereferenced a stored pointer,
+            // which dangled and crashed — review feedback on #51.)
+            out.symbol = n.symbol;
+            out.has_children = n.has_children;
             out.depth = n.depth;
-            out.is_game_node = n.node && n.node->GetFlag(Dasher::CDasherNode::NF_GAME) ? 1 : 0;
+            out.is_game_node = n.is_game_node;
             out.screen_x1 = n.screen_x1;
             out.screen_y1 = n.screen_y1;
             out.screen_x2 = n.screen_x2;
             out.screen_y2 = n.screen_y2;
             out.fill_argb = colorToARGB(n.fill);
             out.outline_argb = colorToARGB(n.outline);
-            out.label_index = -1;
-            if (n.node) {
-                auto* label = n.node->getLabel();
-                if (label && !label->m_strText.empty()) {
-                    ctx->nodeLabelStrings.push_back(label->m_strText);
-                    out.label_index = static_cast<int>(ctx->nodeLabelStrings.size() - 1);
-                }
+            if (!n.label.empty()) {
+                ctx->nodeLabelStrings.push_back(n.label);
+                out.label_index = static_cast<int>(ctx->nodeLabelStrings.size() - 1);
+            } else {
+                out.label_index = -1;
             }
         }
 

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -1835,10 +1835,14 @@ DASHER_API int dasher_get_offset(dasher_ctx* ctx) {
 
 DASHER_API int dasher_set_visible_nodes_enabled(dasher_ctx* ctx, int enabled) {
     if (!ctx || !ctx->intf || !ctx->realized) return -1;
-    auto* view = ctx->intf->GetView();
-    if (!view) return -1;
-    view->SetVisibleNodeCapture(enabled != 0);
-    return 0;
+    try {
+        auto* view = ctx->intf->GetView();
+        if (!view) return -1;
+        view->SetVisibleNodeCapture(enabled != 0);
+        return 0;
+    } catch (...) {
+        return -1;
+    }
 }
 
 DASHER_API int dasher_get_visible_nodes(dasher_ctx* ctx, dasher_node_info* out_nodes, int max_nodes,
@@ -1846,83 +1850,95 @@ DASHER_API int dasher_get_visible_nodes(dasher_ctx* ctx, dasher_node_info* out_n
     if (!ctx || !ctx->intf || !ctx->realized) return -1;
     if (!out_nodes || max_nodes <= 0) return -1;
 
-    auto* view = ctx->intf->GetView();
-    if (!view || !view->IsVisibleNodeCaptureEnabled()) return -1;
+    // CONTRIBUTING Rule 4: never let a C++ exception cross extern "C". Node
+    // accessors (notably GetAlphSymbol, which throws on the base class) can
+    // throw, so the whole body is guarded; the IsSymbolNode() check below keeps
+    // the common path throw-free, and this catch is the safety net.
+    try {
+        auto* view = ctx->intf->GetView();
+        if (!view || !view->IsVisibleNodeCaptureEnabled()) return -1;
 
-    // ABI version check: the caller sets struct_size on the first element.
-    const int caller_size = out_nodes[0].struct_size;
-    const int v1_size = static_cast<int>(sizeof(dasher_node_info));
-    if (caller_size < v1_size) {
-        // Caller is built against an older, smaller struct than this engine.
-        // Filling v1 fields would overflow their allocation.
-        return -1;
-    }
+        // ABI version check: the caller sets struct_size on the first element.
+        const int caller_size = out_nodes[0].struct_size;
+        const int v1_size = static_cast<int>(sizeof(dasher_node_info));
+        if (caller_size < v1_size) {
+            // Caller is built against an older, smaller struct than this engine.
+            // Filling v1 fields would overflow their allocation.
+            return -1;
+        }
 
-    const auto nodes = view->GetVisibleNodes(); // by value; stable copy
+        const auto nodes = view->GetVisibleNodes(); // by value; stable copy
 
-    ctx->nodeLabelStrings.clear();
-    ctx->nodeLabelPtrs.clear();
+        ctx->nodeLabelStrings.clear();
+        ctx->nodeLabelPtrs.clear();
 
-    const int total = static_cast<int>(nodes.size());
-    const int written = std::min(total, max_nodes);
-    for (int i = 0; i < written; ++i) {
-        const auto& n = nodes[i];
-        dasher_node_info& out = out_nodes[i];
-        out.struct_size = v1_size;
-        out.dasher_y1 = static_cast<long long>(n.dasher_y1);
-        out.dasher_y2 = static_cast<long long>(n.dasher_y2);
-        // GetAlphSymbol() throws on the base class (only CSymbolNode overrides
-        // it), so gate it on IsSymbolNode(). Group/control/conversion nodes
-        // report -1.
-        out.symbol = (n.node && n.node->IsSymbolNode()) ? n.node->GetAlphSymbol() : -1;
-        out.has_children = n.node && n.node->ChildCount() > 0 ? 1 : 0;
-        out.depth = n.depth;
-        out.is_game_node = n.node && n.node->GetFlag(Dasher::CDasherNode::NF_GAME) ? 1 : 0;
-        out.screen_x1 = n.screen_x1;
-        out.screen_y1 = n.screen_y1;
-        out.screen_x2 = n.screen_x2;
-        out.screen_y2 = n.screen_y2;
-        out.fill_argb = colorToARGB(n.fill);
-        out.outline_argb = colorToARGB(n.outline);
-        out.label_index = -1;
-        if (n.node) {
-            auto* label = n.node->getLabel();
-            if (label && !label->m_strText.empty()) {
-                ctx->nodeLabelStrings.push_back(label->m_strText);
-                out.label_index = static_cast<int>(ctx->nodeLabelStrings.size() - 1);
+        const int total = static_cast<int>(nodes.size());
+        const int written = std::min(total, max_nodes);
+        for (int i = 0; i < written; ++i) {
+            const auto& n = nodes[i];
+            dasher_node_info& out = out_nodes[i];
+            out.struct_size = v1_size;
+            out.dasher_y1 = static_cast<long long>(n.dasher_y1);
+            out.dasher_y2 = static_cast<long long>(n.dasher_y2);
+            // GetAlphSymbol() throws on the base class (only CSymbolNode
+            // overrides it), so gate it on IsSymbolNode(). Group/control/
+            // conversion nodes report -1.
+            out.symbol = (n.node && n.node->IsSymbolNode()) ? n.node->GetAlphSymbol() : -1;
+            out.has_children = n.node && n.node->ChildCount() > 0 ? 1 : 0;
+            out.depth = n.depth;
+            out.is_game_node = n.node && n.node->GetFlag(Dasher::CDasherNode::NF_GAME) ? 1 : 0;
+            out.screen_x1 = n.screen_x1;
+            out.screen_y1 = n.screen_y1;
+            out.screen_x2 = n.screen_x2;
+            out.screen_y2 = n.screen_y2;
+            out.fill_argb = colorToARGB(n.fill);
+            out.outline_argb = colorToARGB(n.outline);
+            out.label_index = -1;
+            if (n.node) {
+                auto* label = n.node->getLabel();
+                if (label && !label->m_strText.empty()) {
+                    ctx->nodeLabelStrings.push_back(label->m_strText);
+                    out.label_index = static_cast<int>(ctx->nodeLabelStrings.size() - 1);
+                }
             }
         }
+
+        // Build char* pointers for the strings array.
+        ctx->nodeLabelPtrs.resize(ctx->nodeLabelStrings.size());
+        for (size_t i = 0; i < ctx->nodeLabelStrings.size(); ++i)
+            ctx->nodeLabelPtrs[i] = ctx->nodeLabelStrings[i].data();
+
+        if (out_strings) *out_strings = ctx->nodeLabelPtrs.data();
+        if (out_string_count) *out_string_count = static_cast<int>(ctx->nodeLabelPtrs.size());
+
+        // Return the total available count (may exceed max_nodes) so the caller
+        // can grow its buffer and re-query if truncated.
+        return total;
+    } catch (...) {
+        return -1;
     }
-
-    // Build char* pointers for the strings array.
-    ctx->nodeLabelPtrs.resize(ctx->nodeLabelStrings.size());
-    for (size_t i = 0; i < ctx->nodeLabelStrings.size(); ++i)
-        ctx->nodeLabelPtrs[i] = ctx->nodeLabelStrings[i].data();
-
-    if (out_strings) *out_strings = ctx->nodeLabelPtrs.data();
-    if (out_string_count) *out_string_count = static_cast<int>(ctx->nodeLabelPtrs.size());
-
-    // Return the total available count (may exceed max_nodes) so the caller can
-    // grow its buffer and re-query if truncated.
-    return total;
 }
 
 DASHER_API int dasher_get_viewport(dasher_ctx* ctx, dasher_viewport* out) {
     if (!ctx || !ctx->intf || !ctx->realized || !out) return -1;
-    const int caller_size = out->struct_size;
-    const int v1_size = static_cast<int>(sizeof(dasher_viewport));
-    if (caller_size < v1_size) return -1;
-    auto* view = ctx->intf->GetView();
-    if (!view) return -1;
-    const auto vr = view->VisibleRegion();
-    out->struct_size = v1_size;
-    out->crosshair_x = static_cast<long long>(Dasher::CDasherModel::ORIGIN_X);
-    out->crosshair_y = static_cast<long long>(Dasher::CDasherModel::ORIGIN_Y);
-    out->visible_min_y = static_cast<long long>(vr.minY);
-    out->visible_max_y = static_cast<long long>(vr.maxY);
-    out->screen_width = view->Screen()->GetWidth();
-    out->screen_height = view->Screen()->GetHeight();
-    return 0;
+    try {
+        const int caller_size = out->struct_size;
+        const int v1_size = static_cast<int>(sizeof(dasher_viewport));
+        if (caller_size < v1_size) return -1;
+        auto* view = ctx->intf->GetView();
+        if (!view) return -1;
+        const auto vr = view->VisibleRegion();
+        out->struct_size = v1_size;
+        out->crosshair_x = static_cast<long long>(Dasher::CDasherModel::ORIGIN_X);
+        out->crosshair_y = static_cast<long long>(Dasher::CDasherModel::ORIGIN_Y);
+        out->visible_min_y = static_cast<long long>(vr.minY);
+        out->visible_max_y = static_cast<long long>(vr.maxY);
+        out->screen_width = view->Screen()->GetWidth();
+        out->screen_height = view->Screen()->GetHeight();
+        return 0;
+    } catch (...) {
+        return -1;
+    }
 }
 
 // ── Custom actions ─────────────────────────────────────────────────────────

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -15,6 +15,7 @@
 #include "DasherCore/Alphabet/AlphIO.h"
 #include "DasherCore/DasherModel.h"
 #include "DasherCore/DasherNode.h"
+#include "DasherCore/DasherView.h"
 #include "DasherCore/NodeCreationManager.h"
 #include "DasherCore/ControlManager.h"
 #include "DasherCore/LanguageModelling/LMRegistry.h"
@@ -399,6 +400,12 @@ struct dasher_ctx {
     // cross-context bug noted in the codebase review (Tier 1 #4).
     std::vector<std::string> stringValues; // dasher_get_palette_name / alphabet_name / parameter_string_values
     std::string gameTextBuf;               // dasher_game_get_target_text
+
+    // Strand 2 (RFC 0013): label strings for dasher_get_visible_nodes. Owned
+    // here so the returned char** is stable until the next visible_nodes/frame
+    // call, mirroring the command-buffer ownership contract.
+    std::vector<std::string> nodeLabelStrings;
+    std::vector<char*> nodeLabelPtrs;
 
     // Appearance model state (RFC 0007). Lives at the C API layer — appearance
     // is a shell/canvas concern, not a DasherCore engine parameter. Persisted to
@@ -1822,6 +1829,100 @@ DASHER_API int dasher_get_offset(dasher_ctx* ctx) {
     auto* model = ctx->intf->GetModel();
     if (!model) return -1;
     return model->GetOffset();
+}
+
+// ── Custom rendering, Strand 2 (RFC 0013) ──────────────────────────────────
+
+DASHER_API int dasher_set_visible_nodes_enabled(dasher_ctx* ctx, int enabled) {
+    if (!ctx || !ctx->intf || !ctx->realized) return -1;
+    auto* view = ctx->intf->GetView();
+    if (!view) return -1;
+    view->SetVisibleNodeCapture(enabled != 0);
+    return 0;
+}
+
+DASHER_API int dasher_get_visible_nodes(dasher_ctx* ctx, dasher_node_info* out_nodes, int max_nodes,
+                                        char*** out_strings, int* out_string_count) {
+    if (!ctx || !ctx->intf || !ctx->realized) return -1;
+    if (!out_nodes || max_nodes <= 0) return -1;
+
+    auto* view = ctx->intf->GetView();
+    if (!view || !view->IsVisibleNodeCaptureEnabled()) return -1;
+
+    // ABI version check: the caller sets struct_size on the first element.
+    const int caller_size = out_nodes[0].struct_size;
+    const int v1_size = static_cast<int>(sizeof(dasher_node_info));
+    if (caller_size < v1_size) {
+        // Caller is built against an older, smaller struct than this engine.
+        // Filling v1 fields would overflow their allocation.
+        return -1;
+    }
+
+    const auto nodes = view->GetVisibleNodes(); // by value; stable copy
+
+    ctx->nodeLabelStrings.clear();
+    ctx->nodeLabelPtrs.clear();
+
+    const int total = static_cast<int>(nodes.size());
+    const int written = std::min(total, max_nodes);
+    for (int i = 0; i < written; ++i) {
+        const auto& n = nodes[i];
+        dasher_node_info& out = out_nodes[i];
+        out.struct_size = v1_size;
+        out.dasher_y1 = static_cast<long long>(n.dasher_y1);
+        out.dasher_y2 = static_cast<long long>(n.dasher_y2);
+        // GetAlphSymbol() throws on the base class (only CSymbolNode overrides
+        // it), so gate it on IsSymbolNode(). Group/control/conversion nodes
+        // report -1.
+        out.symbol = (n.node && n.node->IsSymbolNode()) ? n.node->GetAlphSymbol() : -1;
+        out.has_children = n.node && n.node->ChildCount() > 0 ? 1 : 0;
+        out.depth = n.depth;
+        out.is_game_node = n.node && n.node->GetFlag(Dasher::CDasherNode::NF_GAME) ? 1 : 0;
+        out.screen_x1 = n.screen_x1;
+        out.screen_y1 = n.screen_y1;
+        out.screen_x2 = n.screen_x2;
+        out.screen_y2 = n.screen_y2;
+        out.fill_argb = colorToARGB(n.fill);
+        out.outline_argb = colorToARGB(n.outline);
+        out.label_index = -1;
+        if (n.node) {
+            auto* label = n.node->getLabel();
+            if (label && !label->m_strText.empty()) {
+                ctx->nodeLabelStrings.push_back(label->m_strText);
+                out.label_index = static_cast<int>(ctx->nodeLabelStrings.size() - 1);
+            }
+        }
+    }
+
+    // Build char* pointers for the strings array.
+    ctx->nodeLabelPtrs.resize(ctx->nodeLabelStrings.size());
+    for (size_t i = 0; i < ctx->nodeLabelStrings.size(); ++i)
+        ctx->nodeLabelPtrs[i] = ctx->nodeLabelStrings[i].data();
+
+    if (out_strings) *out_strings = ctx->nodeLabelPtrs.data();
+    if (out_string_count) *out_string_count = static_cast<int>(ctx->nodeLabelPtrs.size());
+
+    // Return the total available count (may exceed max_nodes) so the caller can
+    // grow its buffer and re-query if truncated.
+    return total;
+}
+
+DASHER_API int dasher_get_viewport(dasher_ctx* ctx, dasher_viewport* out) {
+    if (!ctx || !ctx->intf || !ctx->realized || !out) return -1;
+    const int caller_size = out->struct_size;
+    const int v1_size = static_cast<int>(sizeof(dasher_viewport));
+    if (caller_size < v1_size) return -1;
+    auto* view = ctx->intf->GetView();
+    if (!view) return -1;
+    const auto vr = view->VisibleRegion();
+    out->struct_size = v1_size;
+    out->crosshair_x = static_cast<long long>(Dasher::CDasherModel::ORIGIN_X);
+    out->crosshair_y = static_cast<long long>(Dasher::CDasherModel::ORIGIN_Y);
+    out->visible_min_y = static_cast<long long>(vr.minY);
+    out->visible_max_y = static_cast<long long>(vr.maxY);
+    out->screen_width = view->Screen()->GetWidth();
+    out->screen_height = view->Screen()->GetHeight();
+    return 0;
 }
 
 // ── Custom actions ─────────────────────────────────────────────────────────

--- a/src/DasherCore/AlphabetManager.h
+++ b/src/DasherCore/AlphabetManager.h
@@ -146,6 +146,7 @@ class CSymbolNode : public CAlphNode {
     void GetContext(CDasherInterfaceBase* pInterface, const CAlphabetMap* pAlphabetMap,
                     std::vector<symbol>& vContextSymbols, int iOffset, int iLength) override;
     symbol GetAlphSymbol() override;
+    bool IsSymbolNode() const override { return true; }
     /// Override: if the symbol to create is the same as this node's symbol, return this node instead of creating a new
     /// one
     CDasherNode* RebuildSymbol(CAlphNode* pParent, symbol iSymbol) override;

--- a/src/DasherCore/DasherNode.h
+++ b/src/DasherCore/DasherNode.h
@@ -269,6 +269,12 @@ class Dasher::CDasherNode : private NoClones {
 #endif
     }
 
+    /// True iff this node is an alphabet symbol node (safe to call GetAlphSymbol()
+    /// on without triggering the base-class throw). Default false; CSymbolNode
+    /// overrides to true. Used by the Strand 2 node API to populate `symbol`
+    /// without RTTI in the C-boundary layer.
+    virtual bool IsSymbolNode() const { return false; }
+
     virtual const ColorPalette::Color& getLabelColor(const ColorPalette* colorPalette) = 0;
     virtual const ColorPalette::Color& getOutlineColor(const ColorPalette* colorPalette) = 0;
     virtual const ColorPalette::Color& getNodeColor(const ColorPalette* colorPalette) = 0;

--- a/src/DasherCore/DasherView.h
+++ b/src/DasherCore/DasherView.h
@@ -15,6 +15,7 @@ class CDasherNode;
 #include "Event.h"
 #include "ColorPalette.h"
 
+#include <string>
 #include <vector>
 
 /// \defgroup View Visualisation of the model
@@ -143,7 +144,10 @@ class Dasher::CDasherView {
     /// command buffer draws for the same frame (Strand 1/2 parity).
     /// @{
     struct VisibleNode {
-        CDasherNode* node;       // rendered node (valid until next Render)
+        // Fully-resolved, self-contained snapshot — NO raw CDasherNode* pointer.
+        // The model may free/mutate nodes between Render() and a later query, so
+        // every value the frontend needs is copied here while the node is
+        // guaranteed alive, during the render pass itself.
         Dasher::myint dasher_y1; // node's Dasher-Y range
         Dasher::myint dasher_y2;
         int depth;                // tree depth from root child (cube-extrusion source)
@@ -151,6 +155,10 @@ class Dasher::CDasherView {
         int screen_x2, screen_y2;
         ColorPalette::Color fill;    // node fill colour (from active palette)
         ColorPalette::Color outline; // node outline colour
+        int symbol;                  // alphabet symbol index (-1 for group/control)
+        int has_children;            // 1 if this node had children
+        int is_game_node;            // 1 if on the game-mode path
+        std::string label;           // label text (empty if none)
     };
 
     /// Enable/disable per-node capture during Render(). Off by default.

--- a/src/DasherCore/DasherView.h
+++ b/src/DasherCore/DasherView.h
@@ -15,6 +15,8 @@ class CDasherNode;
 #include "Event.h"
 #include "ColorPalette.h"
 
+#include <vector>
+
 /// \defgroup View Visualisation of the model
 /// @{
 
@@ -129,6 +131,35 @@ class Dasher::CDasherView {
     /// function will blank out around it (in white) if not
     /// @return the innermost node covering the crosshair
     virtual CDasherNode* Render(CDasherNode* pRoot, myint iRootMin, myint iRootMax, CExpansionPolicy& policy) = 0;
+
+    /// @}
+
+    /// @name Node capture (Strand 2 / RFC 0013)
+    /// When enabled, the view records each node it actually draws during Render()
+    /// so a frontend can query the visible node tree and render it itself
+    /// (3D cubes, VR, custom visualisations). Recording is OFF by default and
+    /// is an opt-in via SetVisibleNodeCapture(true) — Strand 1 (command-buffer)
+    /// frontends pay zero overhead. The captured set matches exactly what the
+    /// command buffer draws for the same frame (Strand 1/2 parity).
+    /// @{
+    struct VisibleNode {
+        CDasherNode* node;       // rendered node (valid until next Render)
+        Dasher::myint dasher_y1; // node's Dasher-Y range
+        Dasher::myint dasher_y2;
+        int depth;                // tree depth from root child (cube-extrusion source)
+        int screen_x1, screen_y1; // node's clipped screen bounds
+        int screen_x2, screen_y2;
+        ColorPalette::Color fill;    // node fill colour (from active palette)
+        ColorPalette::Color outline; // node outline colour
+    };
+
+    /// Enable/disable per-node capture during Render(). Off by default.
+    virtual void SetVisibleNodeCapture(bool /*enabled*/) {}
+    /// Whether capture is currently enabled.
+    virtual bool IsVisibleNodeCaptureEnabled() const { return false; }
+    /// Return the nodes captured during the most recent Render() (empty unless
+    /// capture is enabled). Returned by value; valid until the next Render().
+    virtual std::vector<VisibleNode> GetVisibleNodes() const { return {}; }
 
     /// @}
 

--- a/src/DasherCore/DasherViewSquare.cpp
+++ b/src/DasherCore/DasherViewSquare.cpp
@@ -72,6 +72,7 @@ void CDasherViewSquare::SetOrientation(Options::ScreenOrientations newOrient) {
 
 CDasherNode* CDasherViewSquare::Render(CDasherNode* pRoot, myint iRootMin, myint iRootMax, CExpansionPolicy& policy) {
     DASHER_ASSERT(pRoot != 0);
+    if (m_captureVisibleNodes) m_visibleNodes.clear();
     const DasherCoordScreenRegion visibleRegion = VisibleRegion();
     const ScreenRegion screenRegion = {0, 0, Screen()->GetWidth(), Screen()->GetHeight()};
 
@@ -600,6 +601,8 @@ void CDasherViewSquare::DisjointRender(CDasherNode* pRender, myint y1, myint y2,
     pRender->SetFlag(CDasherNode::NF_SUPER,
                      (y2 - y1 >= visibleRegion.maxX) && (y1 <= visibleRegion.minY) && (y2 >= visibleRegion.maxY));
 
+    if (m_captureVisibleNodes) CaptureNode(pRender, y1, y2, 0);
+
     if (pRender->getLabel()) {
         myint ny1 = std::min(visibleRegion.maxY, std::max(visibleRegion.minY, y1)),
               ny2 = std::min(visibleRegion.maxY, std::max(visibleRegion.minY, y2));
@@ -828,6 +831,35 @@ ColorPalette::Color CDasherViewSquare::SimulateTransparency(CDasherNode* pCurren
     return interpolatedColor;
 }
 
+void CDasherViewSquare::CaptureNode(CDasherNode* node, myint y1, myint y2, int depth) {
+    if (!node) return;
+    const DasherCoordScreenRegion vr = VisibleRegion();
+    const myint Range = y2 - y1;
+    // Clipped Dasher-space rect, matching the OVERLAPPING_RECTANGLE draw (the
+    // parity reference shape for Strand 1 vs Strand 2): x in [0, min(Range,maxX)],
+    // y in [max(y1,minY), min(y2,maxY)]. Other shapes (circle/triangle/cube) draw
+    // a subset of this box; for Strand 2 the frontend shapes it itself, so the
+    // bounding box is the right thing to report.
+    const myint dxMaxX = std::min(Range, vr.maxX);
+    const myint dxMinY = std::max(y1, vr.minY);
+    const myint dxMaxY = std::min(y2, vr.maxY);
+    screenint sax, say, sbx, sby;
+    Dasher2Screen(dxMaxX, dxMinY, sax, say);
+    Dasher2Screen(0, dxMaxY, sbx, sby);
+    VisibleNode rec;
+    rec.node = node;
+    rec.dasher_y1 = y1;
+    rec.dasher_y2 = y2;
+    rec.depth = depth;
+    rec.screen_x1 = std::min(sax, sbx);
+    rec.screen_y1 = std::min(say, sby);
+    rec.screen_x2 = std::max(sax, sbx);
+    rec.screen_y2 = std::max(say, sby);
+    rec.fill = node->getNodeColor(m_pColorPalette);
+    rec.outline = node->getOutlineColor(m_pColorPalette);
+    m_visibleNodes.push_back(rec);
+}
+
 void CDasherViewSquare::NewRender(CDasherNode* pCurrentNode, myint y1, myint y2, CTextString* pPrevText,
                                   CExpansionPolicy& policy, double dMaxCost, CDasherNode*& pCurrentTopCenterNode,
                                   CubeDepthLevel nodeDepth, CubeDepthLevel parentDepth,
@@ -891,6 +923,8 @@ void CDasherViewSquare::NewRender(CDasherNode* pCurrentNode, myint y1, myint y2,
                                                            : pCurrentNode->getNodeColor(m_pColorPalette));
         const ColorPalette::Color& outline_color =
             line_width == 0 ? ColorPalette::noColor : pCurrentNode->getOutlineColor(m_pColorPalette);
+
+        if (m_captureVisibleNodes) CaptureNode(pCurrentNode, y1, y2, static_cast<int>(nodeDepth.extrusionLevel));
 
         switch (m_pSettingsStore->GetLongParameter(LP_SHAPE_TYPE)) {
         case Options::OVERLAPPING_RECTANGLE:

--- a/src/DasherCore/DasherViewSquare.cpp
+++ b/src/DasherCore/DasherViewSquare.cpp
@@ -847,7 +847,6 @@ void CDasherViewSquare::CaptureNode(CDasherNode* node, myint y1, myint y2, int d
     Dasher2Screen(dxMaxX, dxMinY, sax, say);
     Dasher2Screen(0, dxMaxY, sbx, sby);
     VisibleNode rec;
-    rec.node = node;
     rec.dasher_y1 = y1;
     rec.dasher_y2 = y2;
     rec.depth = depth;
@@ -857,6 +856,20 @@ void CDasherViewSquare::CaptureNode(CDasherNode* node, myint y1, myint y2, int d
     rec.screen_y2 = std::max(say, sby);
     rec.fill = node->getNodeColor(m_pColorPalette);
     rec.outline = node->getOutlineColor(m_pColorPalette);
+    // Resolve everything that identifies/describes the node NOW, while it is
+    // guaranteed alive. dasher_get_visible_nodes must not dereference the node
+    // later — the model may have freed/mutated it by then.
+    rec.symbol = -1;
+    if (node->IsSymbolNode()) {
+        try {
+            rec.symbol = node->GetAlphSymbol();
+        } catch (...) {
+            rec.symbol = -1; // defensive: GetAlphSymbol throws on the base class
+        }
+    }
+    rec.has_children = node->ChildCount() > 0 ? 1 : 0;
+    rec.is_game_node = node->GetFlag(CDasherNode::NF_GAME) ? 1 : 0;
+    if (auto* label = node->getLabel()) rec.label = label->m_strText;
     m_visibleNodes.push_back(rec);
 }
 

--- a/src/DasherCore/DasherViewSquare.h
+++ b/src/DasherCore/DasherViewSquare.h
@@ -228,6 +228,18 @@ class Dasher::CDasherViewSquare : public CDasherView {
     mutable DasherCoordScreenRegion m_visible_region;
 
     CSettingsStore* m_pSettingsStore;
+
+    // ── Node capture (Strand 2 / RFC 0013) ──────────────────────────────────
+  public:
+    void SetVisibleNodeCapture(bool enabled) override { m_captureVisibleNodes = enabled; }
+    bool IsVisibleNodeCaptureEnabled() const override { return m_captureVisibleNodes; }
+    std::vector<VisibleNode> GetVisibleNodes() const override { return m_visibleNodes; }
+
+  private:
+    bool m_captureVisibleNodes = false;
+    std::vector<VisibleNode> m_visibleNodes;
+    // Record one drawn node's geometry/colour (no-op when capture is off).
+    void CaptureNode(CDasherNode* node, myint y1, myint y2, int depth);
 };
 
 /// @}

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -549,6 +549,70 @@ DASHER_API double dasher_get_wpm(dasher_ctx* ctx);
 // to reset to a specific baseline speed).
 DASHER_API void dasher_reset_cps(dasher_ctx* ctx);
 
+// ── Custom rendering, Strand 2 (RFC 0013) ──────────────────────────────────
+//
+// An alternative to the int[] command buffer (Strand 1): the frontend queries
+// the visible node tree each frame and renders it itself with its own graphics
+// API. Use this for 3D cubes, VR/spatial layouts, custom visualisations, or
+// accessibility views that the flat painter's-algorithm buffer can't express.
+//
+// Capture is OFF by default — call dasher_set_visible_nodes_enabled(ctx, 1)
+// once at setup; then after each dasher_frame() the recorded nodes are
+// available via dasher_get_visible_nodes(). Strand 1 frontends pay zero
+// overhead if they never enable it.
+//
+// The captured node set matches exactly what the command buffer draws for the
+// same frame (Strand 1/Strand 2 parity), so a frontend can mix strands.
+
+// Per-node info. Both structs begin with struct_size, set by the caller to
+// sizeof(...) before the call, so the engine can detect the ABI version and
+// the structs can grow without breaking existing frontends.
+typedef struct dasher_node_info {
+    int struct_size;     // caller sets to sizeof(dasher_node_info)
+    long long dasher_y1; // node's Dasher-Y range
+    long long dasher_y2;
+    int symbol;               // alphabet symbol index (-1 for group/control nodes)
+    int has_children;         // 1 if this node has children
+    int depth;                // tree depth from the rendered root (0 = root)
+    int is_game_node;         // 1 if on the game-mode path
+    int screen_x1, screen_y1; // node's clipped screen bounds
+    int screen_x2, screen_y2;
+    int fill_argb;    // node fill colour (from active palette)
+    int outline_argb; // node outline colour
+    int label_index;  // index into out_strings (-1 if no label)
+} dasher_node_info;
+
+// Viewport state for the frame.
+typedef struct dasher_viewport {
+    int struct_size;         // caller sets to sizeof(dasher_viewport)
+    long long crosshair_x;   // crosshair Dasher X (fixed at the origin)
+    long long crosshair_y;   // crosshair Dasher Y
+    long long visible_min_y; // visible Dasher-Y range
+    long long visible_max_y;
+    int screen_width; // canvas size the engine was told via dasher_set_screen_size
+    int screen_height;
+} dasher_viewport;
+
+// Enable/disable per-frame node capture. Default off. Returns 0 on success,
+// -1 if ctx is null / not realised.
+DASHER_API int dasher_set_visible_nodes_enabled(dasher_ctx* ctx, int enabled);
+
+// Query the visible node tree recorded during the most recent dasher_frame().
+// Nodes are written to out_nodes (up to max_nodes), depth-first (parent before
+// children). Returns the number of nodes written (may exceed max_nodes — call
+// with a larger buffer if so; -1 on error). out_strings/out_string_count hold
+// label text; dasher_node_info.label_index indexes into out_strings.
+//
+// out_nodes, out_strings point into engine-owned buffers valid only until the
+// next dasher_frame() or dasher_get_visible_nodes() call — copy if you need
+// the data beyond the next frame. Returns -1 if capture is disabled or the
+// engine is not realised.
+DASHER_API int dasher_get_visible_nodes(dasher_ctx* ctx, dasher_node_info* out_nodes, int max_nodes,
+                                        char*** out_strings, int* out_string_count);
+
+// Query viewport state. Returns 0 on success, -1 on error.
+DASHER_API int dasher_get_viewport(dasher_ctx* ctx, dasher_viewport* out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_strand2_nodes.cpp
+++ b/tests/test_strand2_nodes.cpp
@@ -236,3 +236,38 @@ TEST_CASE("strand2/bounds within screen and monotone") {
         CHECK(nd.screen_y2 >= 0);
     }
 }
+
+TEST_CASE("strand2/never throws across the C boundary on a long session") {
+    // Regression for the Rule 4 crash: GetAlphSymbol() throws on the base class
+    // and dasher_get_visible_nodes must catch every exception (return -1) rather
+    // than let one cross extern "C" (SIGABRT). A long, deep drive maximises the
+    // chance of hitting any throwing accessor; the test process surviving is the
+    // assertion.
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+
+    dasher_set_speed_percent(ctx, 300);
+    dasher_mouse_move(ctx, 730.0f, 290.0f);
+    dasher_mouse_down(ctx);
+
+    std::vector<dasher_node_info> nodes(256);
+    init_node_info(nodes.data(), 256);
+
+    for (int i = 0; i < 60; ++i) {
+        int* cmds = nullptr;
+        int cc = 0;
+        char** fstrs = nullptr;
+        int fsc = 0;
+        dasher_frame(ctx, 1000 + i * 16, &cmds, &cc, &fstrs, &fsc);
+
+        char** strs = nullptr;
+        int sc = 0;
+        const int n = dasher_get_visible_nodes(ctx, nodes.data(), 256, &strs, &sc);
+        // Always a sane result — never a crash. -1 (capture off / guarded throw)
+        // or a non-negative node count.
+        CHECK(n >= -1);
+        CHECK(n < 100000); // sanity bound
+    }
+
+    dasher_mouse_up(ctx);
+}

--- a/tests/test_strand2_nodes.cpp
+++ b/tests/test_strand2_nodes.cpp
@@ -1,0 +1,238 @@
+// test_strand2_nodes.cpp
+//
+// Tests for the Strand 2 custom-rendering API (RFC 0013):
+//   dasher_set_visible_nodes_enabled / dasher_get_visible_nodes / dasher_get_viewport
+//
+// Key invariant: the node set captured for Strand 2 must match exactly what the
+// Strand 1 command buffer draws for the same frame (Strand 1/Strand 2 parity),
+// so a frontend can mix strands. We verify that each Strand 2 node's screen
+// bounds correspond to an opcode-4 filled rectangle from dasher_frame().
+
+#include "test_common.h"
+
+#include <algorithm>
+#include <set>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+struct Rect {
+    int x1, y1, x2, y2;
+    bool operator<(const Rect& o) const { return std::tie(x1, y1, x2, y2) < std::tie(o.x1, o.y1, o.x2, o.y2); }
+    bool operator==(const Rect& o) const { return std::tie(x1, y1, x2, y2) == std::tie(o.x1, o.y1, o.x2, o.y2); }
+};
+
+// Initialise struct_size on every element of a node buffer (ABI version marker).
+void init_node_info(dasher_node_info* nodes, int n) {
+    for (int i = 0; i < n; ++i)
+        nodes[i].struct_size = sizeof(dasher_node_info);
+}
+
+} // namespace
+
+TEST_CASE("strand2/disabled by default; enabling works") {
+    ScopedContext ctx(800, 600);
+    dasher_node_info nodes[8];
+    init_node_info(nodes, 8);
+    char** strs = nullptr;
+    int sc = 0;
+
+    // Before enabling, capture is off -> dasher_get_visible_nodes returns -1.
+    run_frames(ctx, 3);
+    CHECK(dasher_get_visible_nodes(ctx, nodes, 8, &strs, &sc) == -1);
+
+    // Enable, advance a frame (capture happens during dasher_frame), then query.
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+    run_frames(ctx, 1);
+    const int n = dasher_get_visible_nodes(ctx, nodes, 8, &strs, &sc);
+    CHECK(n > 0);
+}
+
+TEST_CASE("strand2/depth-first preorder invariant on depths") {
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+
+    dasher_set_speed_percent(ctx, 250);
+    dasher_mouse_move(ctx, 720.0f, 300.0f);
+    dasher_mouse_down(ctx);
+    int* cmds = nullptr;
+    int cc = 0;
+    char** strs = nullptr;
+    int sc = 0;
+    dasher_frame(ctx, 1000, &cmds, &cc, &strs, &sc);
+
+    std::vector<dasher_node_info> nodes(64);
+    init_node_info(nodes.data(), 64);
+    const int n = dasher_get_visible_nodes(ctx, nodes.data(), 64, &strs, &sc);
+    dasher_mouse_up(ctx);
+    REQUIRE(n > 0);
+    nodes.resize(std::min(n, 64));
+
+    // First node is the rendered root (depth 0).
+    CHECK(nodes[0].depth == 0);
+
+    // DFS preorder invariant: a node's depth can be at most one greater than
+    // the immediately preceding node's depth (you can only step one level
+    // deeper per recursion; backtracking only goes shallower).
+    for (size_t i = 1; i < nodes.size(); ++i) {
+        CHECK(nodes[i].depth <= nodes[i - 1].depth + 1);
+    }
+}
+
+TEST_CASE("strand2/Strand 1 vs Strand 2 parity (bounds match opcode-4 rects)") {
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+
+    dasher_set_speed_percent(ctx, 200);
+    dasher_mouse_move(ctx, 700.0f, 300.0f);
+    dasher_mouse_down(ctx);
+
+    // One frame: Strand 1 (commands) and Strand 2 (captured nodes) are produced
+    // by the SAME Render() pass, so they must agree.
+    int* cmds = nullptr;
+    int cc = 0;
+    char** strs = nullptr;
+    int sc = 0;
+    dasher_frame(ctx, 1000, &cmds, &cc, &strs, &sc);
+    dasher_mouse_up(ctx);
+
+    // Strand 1: collect opcode-4 (filled rect) bounds.
+    std::multiset<Rect> rects;
+    for (int j = 0; j + 5 < cc; j += 6) {
+        if (cmds[j] == 4) rects.insert({cmds[j + 1], cmds[j + 2], cmds[j + 3], cmds[j + 4]});
+    }
+    REQUIRE(!rects.empty());
+
+    // Strand 2: captured nodes.
+    std::vector<dasher_node_info> nodes(256);
+    init_node_info(nodes.data(), 256);
+    const int n = dasher_get_visible_nodes(ctx, nodes.data(), 256, &strs, &sc);
+    REQUIRE(n > 0);
+    nodes.resize(std::min(n, 256));
+
+    // Every Strand 2 node's bounds must be present in the Strand 1 rect set.
+    // (Strand 1 also emits non-node rects — background/margin blanking — so its
+    //  set is a superset of the node rects.)
+    int matched = 0;
+    for (const auto& nd : nodes) {
+        Rect r{nd.screen_x1, nd.screen_y1, nd.screen_x2, nd.screen_y2};
+        auto it = rects.find(r);
+        if (it != rects.end()) {
+            ++matched;
+            rects.erase(it); // account for multiplicity (distinct nodes)
+        }
+    }
+    CHECK(matched == (int)nodes.size());
+}
+
+TEST_CASE("strand2/labels and symbols are populated") {
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+
+    // The default alphabet's top level is group nodes ("Lower case Latin
+    // letters", ...); symbol nodes live inside them. Drive forward enough to
+    // zoom into a group and expose its symbol children.
+    dasher_set_speed_percent(ctx, 250);
+    dasher_mouse_move(ctx, 720.0f, 300.0f);
+    dasher_mouse_down(ctx);
+    int* cmds = nullptr;
+    int cc = 0;
+    char** s2 = nullptr;
+    int s2c = 0;
+    for (int i = 0; i < 25; ++i)
+        dasher_frame(ctx, 1000 + i * 16, &cmds, &cc, &s2, &s2c);
+    dasher_mouse_up(ctx);
+
+    std::vector<dasher_node_info> nodes(128);
+    init_node_info(nodes.data(), 128);
+    char** strs = nullptr;
+    int sc = 0;
+    const int n = dasher_get_visible_nodes(ctx, nodes.data(), 128, &strs, &sc);
+    REQUIRE(n > 0);
+    nodes.resize(std::min(n, 128));
+
+    // At least one node carries a non-empty label (groups and symbols both have
+    // labels); label indices index into the strings array.
+    int with_label = 0;
+    for (const auto& nd : nodes) {
+        if (nd.label_index >= 0) {
+            CHECK(nd.label_index < sc);
+            CHECK(strs[nd.label_index][0] != '\0');
+            ++with_label;
+        }
+    }
+    CHECK(with_label > 0);
+
+    // Symbol field is sane for every node: -1 for group/control nodes, or a
+    // valid alphabet index for symbol nodes. Driving deep exposes >=1 symbol.
+    const int sym_count = dasher_get_alphabet_symbol_count(ctx);
+    int with_symbol = 0;
+    for (const auto& nd : nodes) {
+        if (nd.symbol >= 0) {
+            CHECK(nd.symbol < sym_count);
+            ++with_symbol;
+        } else {
+            CHECK(nd.symbol == -1);
+        }
+    }
+    CHECK(with_symbol > 0);
+}
+
+TEST_CASE("strand2/viewport matches engine constants and screen size") {
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+    run_frames(ctx, 1);
+
+    dasher_viewport vp;
+    vp.struct_size = sizeof(dasher_viewport);
+    REQUIRE(dasher_get_viewport(ctx, &vp) == 0);
+
+    CHECK(vp.screen_width == 800);
+    CHECK(vp.screen_height == 600);
+    // Crosshair is fixed at the Dasher origin (2048, 2048).
+    CHECK(vp.crosshair_x == 2048);
+    CHECK(vp.crosshair_y == 2048);
+    // Visible Y range straddles the crosshair.
+    CHECK(vp.visible_min_y < 2048);
+    CHECK(vp.visible_max_y > 2048);
+}
+
+TEST_CASE("strand2/struct_size ABI guard rejects undersized caller struct") {
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+    run_frames(ctx, 1);
+
+    dasher_node_info nodes[2];
+    init_node_info(nodes, 2);
+    char** strs = nullptr;
+    int sc = 0;
+
+    // Caller claims a struct smaller than the engine's -> engine refuses rather
+    // than overflow the caller's allocation.
+    nodes[0].struct_size = 4;
+    CHECK(dasher_get_visible_nodes(ctx, nodes, 2, &strs, &sc) == -1);
+}
+
+TEST_CASE("strand2/bounds within screen and monotone") {
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+    run_frames(ctx, 1);
+
+    std::vector<dasher_node_info> nodes(64);
+    init_node_info(nodes.data(), 64);
+    char** strs = nullptr;
+    int sc = 0;
+    const int n = dasher_get_visible_nodes(ctx, nodes.data(), 64, &strs, &sc);
+    REQUIRE(n > 0);
+    nodes.resize(std::min(n, 64));
+
+    for (const auto& nd : nodes) {
+        CHECK(nd.screen_x1 <= nd.screen_x2);
+        CHECK(nd.screen_y1 <= nd.screen_y2);
+        // Bounds may extend slightly off-canvas (clipped to the visible region in
+        // Dasher space, not the canvas), but the top-left should be sane.
+        CHECK(nd.screen_x2 >= 0);
+        CHECK(nd.screen_y2 >= 0);
+    }
+}

--- a/tests/test_strand2_nodes.cpp
+++ b/tests/test_strand2_nodes.cpp
@@ -237,6 +237,39 @@ TEST_CASE("strand2/bounds within screen and monotone") {
     }
 }
 
+TEST_CASE("strand2/snapshot survives node lifetime changes (no dangling deref)") {
+    // Regression for the use-after-free crash: the old design stored raw
+    // CDasherNode* pointers during Render() and dereferenced them in the query;
+    // by then the model could have freed/mutated those nodes. The snapshot is
+    // now fully resolved during Render(), so changing node lifetimes between the
+    // frame and the query must not crash (or, under ASan, fault).
+    ScopedContext ctx(800, 600);
+    REQUIRE(dasher_set_visible_nodes_enabled(ctx, 1) == 0);
+
+    dasher_set_speed_percent(ctx, 250);
+    dasher_mouse_move(ctx, 720.0f, 300.0f);
+    dasher_mouse_down(ctx);
+    int* cmds = nullptr;
+    int cc = 0;
+    char** fstrs = nullptr;
+    int fsc = 0;
+    for (int i = 0; i < 20; ++i)
+        dasher_frame(ctx, 1000 + i * 16, &cmds, &cc, &fstrs, &fsc);
+    dasher_mouse_up(ctx);
+
+    // Force a model reset, which rebuilds/frees the node tree the snapshot was
+    // taken from. The query must read only the pre-resolved snapshot — never
+    // dereference a freed node — so this must not crash.
+    dasher_reset(ctx);
+
+    std::vector<dasher_node_info> nodes(64);
+    init_node_info(nodes.data(), 64);
+    char** strs = nullptr;
+    int sc = 0;
+    const int n = dasher_get_visible_nodes(ctx, nodes.data(), 64, &strs, &sc);
+    CHECK(n >= -1); // -1 (capture reset) or a non-negative count; never a crash
+}
+
 TEST_CASE("strand2/never throws across the C boundary on a long session") {
     // Regression for the Rule 4 crash: GetAlphSymbol() throws on the base class
     // and dasher_get_visible_nodes must catch every exception (return -1) rather


### PR DESCRIPTION
Implements **Strand 2** from governance RFC 0013 (dasher-project/governance#20): a frontend can query the visible node tree each frame and render it itself — 3D cubes, VR/spatial layouts, custom visualisations, accessibility views — instead of consuming the flat `int[]` command buffer. Strands coexist.

This is the proper fix for cube mode (issue #49): frontends render real 3D cubes from node data + their own graphics pipeline, replacing the withdrawn opcode-7 experiment (#50, closed unmerged).

## New C API (`dasher.h`)

```c
dasher_set_visible_nodes_enabled(ctx, 1)            // opt-in; OFF by default
dasher_get_visible_nodes(ctx, out_nodes, max, &strs, &str_count)
dasher_get_viewport(ctx, &vp)
```

- `dasher_node_info`: `struct_size`, Dasher-Y range, `symbol` (-1 for group/control), `has_children`, `depth` (tree depth — cube-extrusion source), `is_game_node`, clipped screen bounds, `fill_argb`/`outline_argb`, `label_index`.
- `dasher_viewport`: crosshair (fixed at origin), visible Y range, canvas size.
- Both structs carry a caller-set `struct_size` field for ABI evolution (per the RFC).
- Returned pointers are engine-owned, valid until the next `dasher_frame` / `dasher_get_visible_nodes` call.

**Opt-in by default:** Strand 1 frontends that never call `dasher_set_visible_nodes_enabled` pay zero overhead — the per-node recording only runs when capture is on.

## How it's captured

Recording happens inside `CDasherViewSquare::NewRender`/`DisjointRender`, at each node actually drawn. So the captured node set matches **exactly** what the command buffer draws for the same frame (Strand 1/Strand 2 parity). The bounds use the same clip formula as the `OVERLAPPING_RECTANGLE` draw (the parity reference shape).

Minor core additions:
- `CDasherNode::IsSymbolNode()` virtual — `GetAlphSymbol()` throws on the base class (only `CSymbolNode` overrides), so the C boundary gates on `IsSymbolNode()` rather than RTTI or try/catch.
- `CDasherView` gains a `VisibleNode` struct + `SetVisibleNodeCapture` / `IsVisibleNodeCaptureEnabled` / `GetVisibleNodes` virtuals (default no-ops; only `CDasherViewSquare` records).

## Tests (`test_strand2_nodes.cpp`)

- disabled by default; enabling works
- depth-first preorder invariant on depths (`depth[i] <= depth[i-1]+1`, first node depth 0)
- **Strand 1 vs Strand 2 parity**: every captured node's screen bounds matches an opcode-4 filled rectangle from `dasher_frame()` for the same frame (the key invariant)
- labels populated (group + symbol nodes); label indices index the strings array
- symbol field sane (-1 for group/control nodes, valid index otherwise) and symbol nodes appear when the tree is zoomed past the top-level groups
- viewport matches engine constants (crosshair 2048,2048) + canvas size
- `struct_size` ABI guard rejects undersized caller structs
- bounds monotone within the canvas

## Verification
- clang-format clean (`--Werror` dry-run)
- Debug build: strand2/cube/circle/draw-snapshot/draw-command tests pass
- Strand 1 golden tests (`draw_snapshot`, `draw_command`) unchanged — capture is off by default, so the command-buffer path is untouched

## Open follow-ups (not in this PR)
- Non-node colours (background, crosshair, game-guide): the RFC's remaining open question (Q2) on a separate `dasher_get_palette_colors`. v1 ships per-node colours only.
- C_API.md docs for the new functions (will add before merge unless reviewers want it here).