### PR TITLE
fix: default BP_AUTOCALIBRATE to true (restore v5 behaviour)

### DIFF
--- a/settings_manifest.json
+++ b/settings_manifest.json
@@ -148,7 +148,7 @@
       "key": "BP_AUTOCALIBRATE",
       "storageName": "Autocalibrate",
       "type": "bool",
-      "default": false,
+      "default": true,
       "label": "Auto-Calibrate Target",
       "description": "Automatically adjusts the 'straight-ahead' point based on the user's average pointer position.",
       "uiType": "Switch",
@@ -369,10 +369,22 @@
       "group": "Customization",
       "subgroup": "Layout",
       "enumValues": [
-        {"label": "Automatic", "cppExpr": "-2"},
-        {"label": "Normal", "cppExpr": "0"},
-        {"label": "Left-Handed", "cppExpr": "1"},
-        {"label": "Right-Handed", "cppExpr": "2"}
+        {
+          "label": "Automatic",
+          "cppExpr": "-2"
+        },
+        {
+          "label": "Normal",
+          "cppExpr": "0"
+        },
+        {
+          "label": "Left-Handed",
+          "cppExpr": "1"
+        },
+        {
+          "label": "Right-Handed",
+          "cppExpr": "2"
+        }
       ]
     },
     {
@@ -420,10 +432,22 @@
       "group": "Language",
       "subgroup": "Learning",
       "enumValues": [
-        {"label": "PPM", "cppExpr": "0"},
-        {"label": "Word", "cppExpr": "2"},
-        {"label": "Mixture", "cppExpr": "3"},
-        {"label": "CTW", "cppExpr": "4"}
+        {
+          "label": "PPM",
+          "cppExpr": "0"
+        },
+        {
+          "label": "Word",
+          "cppExpr": "2"
+        },
+        {
+          "label": "Mixture",
+          "cppExpr": "3"
+        },
+        {
+          "label": "CTW",
+          "cppExpr": "4"
+        }
       ]
     },
     {
@@ -470,13 +494,34 @@
       "group": "Customization",
       "subgroup": "Appearance",
       "enumValues": [
-        {"label": "Disjoint Rectangles", "cppExpr": "static_cast<long>(Options::DISJOINT_RECTANGLE)"},
-        {"label": "Overlapping Rectangles", "cppExpr": "static_cast<long>(Options::OVERLAPPING_RECTANGLE)"},
-        {"label": "Triangles", "cppExpr": "static_cast<long>(Options::TRIANGLE)"},
-        {"label": "Truncated Triangles", "cppExpr": "static_cast<long>(Options::TRUNCATED_TRIANGLE)"},
-        {"label": "Quadric", "cppExpr": "static_cast<long>(Options::QUADRIC)"},
-        {"label": "Circle", "cppExpr": "static_cast<long>(Options::CIRCLE)"},
-        {"label": "Cube", "cppExpr": "static_cast<long>(Options::CUBE)"}
+        {
+          "label": "Disjoint Rectangles",
+          "cppExpr": "static_cast<long>(Options::DISJOINT_RECTANGLE)"
+        },
+        {
+          "label": "Overlapping Rectangles",
+          "cppExpr": "static_cast<long>(Options::OVERLAPPING_RECTANGLE)"
+        },
+        {
+          "label": "Triangles",
+          "cppExpr": "static_cast<long>(Options::TRIANGLE)"
+        },
+        {
+          "label": "Truncated Triangles",
+          "cppExpr": "static_cast<long>(Options::TRUNCATED_TRIANGLE)"
+        },
+        {
+          "label": "Quadric",
+          "cppExpr": "static_cast<long>(Options::QUADRIC)"
+        },
+        {
+          "label": "Circle",
+          "cppExpr": "static_cast<long>(Options::CIRCLE)"
+        },
+        {
+          "label": "Cube",
+          "cppExpr": "static_cast<long>(Options::CUBE)"
+        }
       ]
     },
     {
@@ -511,7 +556,7 @@
       "type": "long",
       "default": 50,
       "label": "Uniform Probability",
-      "description": "Uniform probability weight (×1000). Higher values make less-probable symbols larger.",
+      "description": "Uniform probability weight (\u00d71000). Higher values make less-probable symbols larger.",
       "uiType": "Slider",
       "min": 0,
       "max": 1000,

--- a/src/DasherCore/Parameters.cpp
+++ b/src/DasherCore/Parameters.cpp
@@ -68,7 +68,7 @@ const std::unordered_map<Parameter, const Parameter_Value> parameter_defaults = 
                      "Precise Dynamics", Settings::UIControlType::Switch, true, "BP_EXACT_DYNAMICS", "CDynamicFilter",
                      "Input"}},
     {BP_AUTOCALIBRATE,
-     Parameter_Value{"Autocalibrate", PARAM_BOOL, Persistence::PERSISTENT, false,
+     Parameter_Value{"Autocalibrate", PARAM_BOOL, Persistence::PERSISTENT, true,
                      "Automatically adjusts the 'straight-ahead' point based on the user's average pointer position.",
                      "Auto-Calibrate Target", Settings::UIControlType::Switch, false, "BP_AUTOCALIBRATE",
                      "CDefaultFilter", "Input"}},


### PR DESCRIPTION
Restores `BP_AUTOCALIBRATE` to `true` (on by default), matching v5. The v6 rewrite had flipped it to `false` without a documented rationale.

**Why on by default:**
- **Safe for accurate pointers.** The algorithm only fires when accumulated bias exceeds `MAX_Y/2` over ~10 frames; for mouse/touch, random noise cancels and the threshold is never reached — it is effectively a no-op.
- **Eye-tracker users need it.** Eye tracking drifts; autocalibration corrects continuously without a calibration step. Having it off by default means a clinician must know to find and toggle "Auto-Calibrate Target" in Settings → Input.
- **v5 had it on.** MacKay's team chose `true`; the flip was undocumented.

Changes: `Parameters.cpp` default value `false → true`; `settings_manifest.json` `"default": false → true`.