### PR TITLE
fix(capi): permitted-values probe call returned 0 before querying

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -1394,13 +1394,19 @@ DASHER_API int dasher_get_parameter_enum_value(int key, int index) {
 }
 
 DASHER_API int dasher_get_parameter_string_values(dasher_ctx* ctx, int key, const char** out_names, int max_out) {
-    if (!out_names || max_out <= 0) return 0;
     if (!ctx) return 0;
     ctx->stringValues.clear();
 
     if (ctx->intf) {
         ctx->stringValues = ctx->intf->GetPermittedValues(static_cast<Dasher::Parameter>(key));
     }
+
+    // Probe call (null buffer / zero capacity): return the full count so
+    // callers can size a buffer and call again. Previously this returned 0
+    // before ever querying the engine, so every permitted-value list (e.g.
+    // the 622 alphabets) came back empty and frontends rendered blank
+    // pickers.
+    if (!out_names || max_out <= 0) return static_cast<int>(ctx->stringValues.size());
 
     int count = static_cast<int>(ctx->stringValues.size());
     if (count > max_out) count = max_out;

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -1,5 +1,8 @@
 // Extended C API tests: cover functions not tested in test_capi.cpp
 #include "test_common.h"
+
+#include <cstring>
+#include <vector>
 TEST(long_string_params) {
     dasher_ctx* ctx = create_isolated_context();
     ASSERT(ctx != nullptr);
@@ -294,15 +297,32 @@ TEST(string_values) {
     int alph_key = dasher_find_parameter_key("SP_ALPHABET_ID");
     ASSERT(alph_key >= 0);
 
-    const char* values_buf[32] = {nullptr};
-    int count = dasher_get_parameter_string_values(ctx, alph_key, values_buf, 32);
+    // Probe call first: must return the full count (regression: it used to
+    // return 0 before querying, so every permitted-value list looked empty
+    // and frontends rendered blank pickers).
+    const int probe_count = dasher_get_parameter_string_values(ctx, alph_key, nullptr, 0);
+    ASSERT(probe_count > 0);
+
+    std::vector<const char*> values_buf(probe_count, nullptr);
+    int count = dasher_get_parameter_string_values(ctx, alph_key, values_buf.data(), probe_count);
     printf("  String values count: %d\n", count);
-    ASSERT(count > 0);
+    ASSERT(count == probe_count);
 
     for (int i = 0; i < count && i < 5; i++) {
         ASSERT(values_buf[i] != nullptr);
         printf("  Value %d: '%s'\n", i, values_buf[i]);
     }
+
+    // The engine's current alphabet must be one of the permitted values.
+    const char* current = dasher_get_alphabet_id(ctx);
+    bool found = false;
+    for (int i = 0; i < count; i++) {
+        if (values_buf[i] && current && strcmp(values_buf[i], current) == 0) {
+            found = true;
+            break;
+        }
+    }
+    ASSERT(found);
 
     dasher_destroy(ctx);
 }


### PR DESCRIPTION
Found the hard way: Dasher-GTK's footer alphabet dropdown was blank despite the engine carrying 475 alphabets.

## Root cause

`dasher_get_parameter_string_values(ctx, key, nullptr, 0)` — the documented count-only probe — had its early-out **before** the engine query:

```c
if (!out_names || max_out <= 0) return 0;   // returned 0 without querying
```

Every caller using the two-call pattern (probe for count, then fetch — exactly what Dasher-GTK's bridge does) got an empty list for **every** permitted-values parameter: alphabets, palettes, input filters.

## Fix

The probe now populates `ctx->stringValues` and returns the full count; callers size a buffer and call again as documented. Verified with a standalone harness against the engine: **475 alphabet names enumerate**, and the engine's current alphabet is present in the list (index 105).

## Test

`string_values` in test_capi_extended now asserts: probe count > 0, probe count == fetch count, and the current alphabet is among the permitted values. Full suite 39/39 green.

Same family as the GTK blank-picker symptoms (its dropdown refresh landed app-side, but the list API itself was the blocker).

DCO signed.