### PR TITLE
fix(fileutils): never regex an absolute path - dasher_create failed on fresh user dirs

### DIFF
--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -39,11 +39,19 @@ int Dasher::FileUtils::GetFileSize(const std::string& strFileName) {
 }
 
 void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& strPattern) {
-    // Absolute path to a real file -> parse only that file
+    // Absolute paths name one specific file, never a glob. If the file is
+    // missing, return instead of falling through to the regex: compiling a
+    // Windows path as a regex throws on its backslashes ("\2" is parsed as
+    // a backreference, "\c" as an invalid control escape), which made
+    // dasher_create fail whenever the settings file did not exist yet
+    // (fresh user dir) — XmlSettingsStore::Load() ScanFiles()s the
+    // settings path itself.
     std::error_code error_code; // just used for not throwing errors
     std::filesystem::path p(strPattern);
-    if (p.is_absolute() && std::filesystem::exists(p, error_code) && std::filesystem::is_regular_file(p, error_code)) {
-        parser->ParseFile(strPattern, IsFileWriteable(strPattern));
+    if (p.is_absolute()) {
+        if (std::filesystem::exists(p, error_code) && std::filesystem::is_regular_file(p, error_code)) {
+            parser->ParseFile(strPattern, IsFileWriteable(strPattern));
+        }
         return;
     }
 

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -195,6 +195,31 @@ TEST(reset) {
     dasher_destroy(ctx);
 }
 
+TEST(create_with_fresh_user_dir_regex_hazard_path) {
+    // Regression: XmlSettingsStore::Load() passes the settings file's
+    // absolute path to ScanFiles(); when the file does not exist yet
+    // (fresh user dir - the normal first-run case) the old code fell
+    // through to std::regex(pattern), and Windows paths throw there:
+    // backslashes become escapes, so a final component starting with a
+    // digit ("\2" -> backreference) or 'c' ("\c" -> control escape) made
+    // dasher_create fail outright. A path component of "2c" makes the
+    // hazard deterministic; both sequential creates must succeed.
+    const std::string data = get_test_data_dir();
+
+    for (int i = 0; i < 2; i++) {
+        ScopedTempDir tmp; // fresh dir each iteration => no settings file yet
+        std::error_code ec;
+        const auto hazard = std::filesystem::path(tmp.path) / "2c";
+        std::filesystem::create_directories(hazard, ec);
+
+        char* err = nullptr;
+        dasher_ctx* ctx = dasher_create(data.c_str(), hazard.string().c_str(), &err);
+        if (!ctx) printf("  create #%d failed: %s\n", i, err ? err : "(no error string)");
+        ASSERT(ctx != nullptr);
+        dasher_destroy(ctx);
+    }
+}
+
 TEST(reset_emits_buffer_clear_event) {
     // Resets clear the edit buffer without insert/delete deltas, so they must
     // announce themselves as event type 2 — subscribers keeping a shadow


### PR DESCRIPTION
﻿## Summary

`dasher_create` fails with `regex_error` whenever the settings file does not exist yet (fresh user dir — the normal first-run case) **and** the user-dir path contains a backslash escape that MSVC's `std::regex` rejects.

### Root cause

`XmlSettingsStore::Load()` (`src/DasherCore/XmlSettingsStore.cpp:21`) passes the settings file's **absolute path** to `FileUtils::ScanFiles()`. `ScanFiles`' direct-parse branch requires the file to *exist*; when it doesn't, the old code fell through to `std::regex(strPattern)` — compiling a Windows path as a regex. The backslashes become escapes:

- a final component starting with a digit → `\2` = backreference to an undefined group → `regex_error(error_backref)`
- a component starting with `c` → `\c47…` = invalid control escape → `regex_error(error_escape)`

MSVC treats unknown identity escapes (`\U`, `\A`, `\D`) leniently as literals, so `%APPDATA%`-style paths survive by luck while temp/GUID-style paths throw ~70% of the time (GUID content dependent).

### How it was found

The new Dasher-Windows integration tests (Dasher-Windows #37) create/destroy/create engines with fresh GUID temp dirs and failed non-deterministically. Minimal repro outside any test framework: three `dasher_create` calls with GUID user dirs — #1 may pass, the rest throw. Local diagnostic build printing the offending pattern bytes confirmed the pattern is the settings path itself:

```
[ScanFiles] regex_error (error_backref) on pattern len=103 bytes: 43 3a 5c 55 73 65 72 73 ... ("\C:\Users\...\dasher_settings.xml")
```

### Fix

`ScanFiles` now returns early for **any** absolute path when the file is missing — an absolute path names one specific file, never a glob — and regex globbing remains for relative patterns (`alphabet.*.xml` etc.). No behavioural change for existing callers: existing-file absolute paths still parse directly; relative globs are untouched.

### Test

`create_with_fresh_user_dir_regex_hazard_path` (test_capi_extended.cpp): two sequential creates into fresh user dirs whose final component is `2c` (digit start forces `\2` deterministically). Verified locally:

- pre-fix: `create #0 failed: Failed to create Dasher session: regex_error(error_backref)`
- post-fix: both creates succeed

(Note: two *unrelated* extended tests — `reset`, `game_mode_basic` — fail in my local environment both pre- and post-fix due to locale/training data on this machine; CI is the authority for those. My change is not in their path.)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Cross-platform / parity change (Windows-path specific, but the guard is platform-neutral)

## Definition of Done

- [x] Builds cleanly; new regression test fails pre-fix / passes post-fix
- [x] Commits are signed off (DCO)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents missing absolute file paths from falling through to regex-based file discovery, fixing first-run creation failures on Windows.
- Treats every absolute path as one exact file and returns cleanly when it is absent or non-regular.
- Preserves regex discovery for relative file patterns.
- Adds a regression test using a deterministic backreference-like Windows path component.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified in the changed behavior.

Current absolute-path usage names the settings file directly, where absence is an expected first-run condition, while existing regex-based discovery continues to use relative patterns.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/DasherCore/FileUtils.cpp | Correctly separates exact absolute-file handling from relative regex discovery without disrupting current callers. |
| tests/test_capi_extended.cpp | Adds focused Windows regression coverage for creating sessions with fresh user directories whose paths previously triggered regex errors. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(fileutils): never regex an absolute ..."](https://github.com/dasher-project/dashercore/commit/9fb5e51e95b5152202ef38214a46d4f6084d23df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56795924)</sub>

<!-- /greptile_comment -->