### PR TITLE
fix(capi): stamp input events on the engine frame timeline, not steady_clock

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -702,11 +702,14 @@ struct dasher_ctx {
 // subtracts input stamps from frame times, so mixing clocks corrupts
 // framerate/slow-start state at every stop/restart (#60). Multiple inputs
 // within one frame window get strictly increasing stamps so gesture timing
-// (stylus tap vs hold, multi-press) still sees distinct timestamps.
+// (stylus tap vs hold, multi-press) still sees distinct timestamps — but
+// capped 2ms past the frame time, so a burst of same-frame inputs can never
+// outrun the next frame stamp and underflow the unsigned elapsed-time math
+// downstream (slow-start).
 static unsigned long inputTime(dasher_ctx* ctx) {
     if (ctx->lastInputMs < ctx->lastFrameMs)
         ctx->lastInputMs = ctx->lastFrameMs;
-    else
+    else if (ctx->lastInputMs < ctx->lastFrameMs + 2)
         ctx->lastInputMs += 1;
     return static_cast<unsigned long>(ctx->lastInputMs);
 }

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -465,6 +465,15 @@ struct dasher_ctx {
     Dasher::CDashIntfScreenMsgs* intf = nullptr;
     std::string editBuffer;
     size_t cursorPos = 0;
+    // The engine's own timeline: the timestamp of the most recent
+    // dasher_frame(). Input events (mouse/key) are stamped with this so the
+    // engine never subtracts across clocks — frontends pass their own
+    // timeline to dasher_frame (compositor frame time, uptime, anything),
+    // and mixing that with a steady_clock stamp here poisoned
+    // LP_FRAMERATE/slow-start at every stop/restart (the Windows + Android
+    // restart drift, #60). v5 never had this because its frontends embedded
+    // the engine on one clock.
+    int64_t lastFrameMs = 0;
     // Typing rate tracker (RFC 0012): timestamps of recent character outputs.
     std::deque<std::chrono::steady_clock::time_point> rateTimestamps;
     std::string tlString;
@@ -683,6 +692,12 @@ struct dasher_ctx {
         }
     };
 };
+
+// Stamp for input events arriving between frames: the engine's own timeline
+// (the most recent dasher_frame time), never steady_clock — the engine
+// subtracts input stamps from frame times, so mixing clocks corrupts
+// framerate/slow-start state at every stop/restart (#60).
+static unsigned long inputTime(const dasher_ctx* ctx) { return static_cast<unsigned long>(ctx->lastFrameMs); }
 
 // ── C API Boundary Exception Helpers ────────────────────────────────────────
 // Enforces Rule 4: never throw across the C API boundary. All exceptions are
@@ -958,7 +973,7 @@ DASHER_API void dasher_mouse_down(dasher_ctx* ctx) {
         // only hovering inside the circle should. (Steve Saling feedback)
         if (ctx->intf->GetLongParameter(Dasher::LP_START_MODE) == Dasher::Options::StartMode::circle_start) return;
         ctx->intf->SetBoolParameter(Dasher::BP_START_MOUSE, true);
-        ctx->intf->KeyDown(nowMs(), Dasher::Keys::Primary_Input);
+        ctx->intf->KeyDown(inputTime(ctx), Dasher::Keys::Primary_Input);
     } catch (const std::exception& e) {
         log_boundary_error(ctx, "dasher_mouse_down", e.what());
         ctx->engineError = true;
@@ -974,7 +989,7 @@ DASHER_API void dasher_mouse_up(dasher_ctx* ctx) {
     if (!ctx->mouseDown) return;
     ctx->mouseDown = false;
     try {
-        ctx->intf->KeyUp(nowMs(), Dasher::Keys::Primary_Input);
+        ctx->intf->KeyUp(inputTime(ctx), Dasher::Keys::Primary_Input);
     } catch (const std::exception& e) {
         log_boundary_error(ctx, "dasher_mouse_up", e.what());
         ctx->engineError = true;
@@ -990,9 +1005,9 @@ DASHER_API void dasher_key_event(dasher_ctx* ctx, int key, int pressed) {
     try {
         auto vk = static_cast<Dasher::Keys::VirtualKey>(key);
         if (pressed) {
-            ctx->intf->KeyDown(nowMs(), vk);
+            ctx->intf->KeyDown(inputTime(ctx), vk);
         } else {
-            ctx->intf->KeyUp(nowMs(), vk);
+            ctx->intf->KeyUp(inputTime(ctx), vk);
         }
     } catch (const std::exception& e) {
         log_boundary_error(ctx, "dasher_key_event", e.what());
@@ -1009,6 +1024,10 @@ DASHER_API void dasher_frame(dasher_ctx* ctx, int64_t time_ms, int** out_command
     if (out_command_count) *out_command_count = 0;
     if (out_strings) *out_strings = nullptr;
     if (out_string_count) *out_string_count = 0;
+
+    // Anchor the engine timeline before anything else: input events between
+    // frames are stamped from this (see dasher_ctx::lastFrameMs).
+    if (ctx) ctx->lastFrameMs = time_ms > 0 ? time_ms : 0;
 
     if (!ctx || !ctx->intf || !ctx->screen || !ctx->realized) return;
     if (ctx->engineError) return;
@@ -1083,7 +1102,7 @@ DASHER_API void dasher_set_alphabet_id(dasher_ctx* ctx, const char* alphabet_id)
     }
     if (ctx->intf->GetStringParameter(Dasher::SP_ALPHABET_ID) == alphabet_id) return;
     if (ctx->mouseDown) {
-        ctx->intf->KeyUp(nowMs(), Dasher::Keys::Primary_Input);
+        ctx->intf->KeyUp(inputTime(ctx), Dasher::Keys::Primary_Input);
         ctx->mouseDown = false;
     }
     ctx->intf->SetStringParameter(Dasher::SP_ALPHABET_ID, alphabet_id);
@@ -1456,7 +1475,7 @@ DASHER_API int dasher_get_palette_preview_colors(dasher_ctx* ctx, int index, int
 DASHER_API void dasher_set_palette(dasher_ctx* ctx, const char* palette_name) {
     if (!ctx || !ctx->intf || !palette_name) return;
     if (ctx->mouseDown) {
-        ctx->intf->KeyUp(nowMs(), Dasher::Keys::Primary_Input);
+        ctx->intf->KeyUp(inputTime(ctx), Dasher::Keys::Primary_Input);
         ctx->mouseDown = false;
     }
     // Route through the appearance model (RFC 0007): this sets the user's

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -474,6 +474,10 @@ struct dasher_ctx {
     // restart drift, #60). v5 never had this because its frontends embedded
     // the engine on one clock.
     int64_t lastFrameMs = 0;
+    // Last input-event stamp (see inputTime): strictly increasing across
+    // consecutive inputs within one frame window, so intra-frame gesture
+    // ordering/durations survive.
+    int64_t lastInputMs = 0;
     // Typing rate tracker (RFC 0012): timestamps of recent character outputs.
     std::deque<std::chrono::steady_clock::time_point> rateTimestamps;
     std::string tlString;
@@ -696,8 +700,16 @@ struct dasher_ctx {
 // Stamp for input events arriving between frames: the engine's own timeline
 // (the most recent dasher_frame time), never steady_clock — the engine
 // subtracts input stamps from frame times, so mixing clocks corrupts
-// framerate/slow-start state at every stop/restart (#60).
-static unsigned long inputTime(const dasher_ctx* ctx) { return static_cast<unsigned long>(ctx->lastFrameMs); }
+// framerate/slow-start state at every stop/restart (#60). Multiple inputs
+// within one frame window get strictly increasing stamps so gesture timing
+// (stylus tap vs hold, multi-press) still sees distinct timestamps.
+static unsigned long inputTime(dasher_ctx* ctx) {
+    if (ctx->lastInputMs < ctx->lastFrameMs)
+        ctx->lastInputMs = ctx->lastFrameMs;
+    else
+        ctx->lastInputMs += 1;
+    return static_cast<unsigned long>(ctx->lastInputMs);
+}
 
 // ── C API Boundary Exception Helpers ────────────────────────────────────────
 // Enforces Rule 4: never throw across the C API boundary. All exceptions are

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -225,7 +225,8 @@ TEST(restart_keeps_typing_after_stop_start_cycle) {
 
     // First run: types normally (same setup as the reset test).
     dasher_mouse_down(ctx);
-    for (int i = 0; i < 300; i++) frame();
+    for (int i = 0; i < 300; i++)
+        frame();
     dasher_mouse_up(ctx);
     const size_t len1 = outLen();
     const long f1 = dasher_get_long_parameter(ctx, fr_key);
@@ -233,17 +234,20 @@ TEST(restart_keeps_typing_after_stop_start_cycle) {
 
     // Stop, then restart.
     dasher_mouse_down(ctx);
-    for (int i = 0; i < 5; i++) frame();
+    for (int i = 0; i < 5; i++)
+        frame();
     dasher_mouse_up(ctx);
 
     dasher_mouse_down(ctx);
-    for (int i = 0; i < 4; i++) frame();
+    for (int i = 0; i < 4; i++)
+        frame();
     // Sample the restart transient: pre-fix, the first post-restart window
     // was seeded from a steady_clock stamp and measured ~0 fps, collapsing
     // LP_FRAMERATE to ~half (observed 4999 -> 2499) and doubling step sizes
     // for ~10 frames — the "canvas pulls you much higher" restart fling.
     const long f2 = dasher_get_long_parameter(ctx, fr_key);
-    for (int i = 0; i < 146; i++) frame();
+    for (int i = 0; i < 146; i++)
+        frame();
     dasher_mouse_up(ctx);
     const size_t len2 = outLen();
 

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -195,6 +195,67 @@ TEST(reset) {
     dasher_destroy(ctx);
 }
 
+TEST(restart_keeps_typing_after_stop_start_cycle) {
+    // Regression (#60 — restart drift reported on Windows + Android): input
+    // events were stamped with steady_clock while dasher_frame runs on the
+    // frontend's own timeline. run() seeds the framerate window and
+    // slow-start clock from the input stamp, so a start subtracted across
+    // two clocks: the first sample window measured garbage, LP_FRAMERATE (a
+    // decaying average) collapsed, the next step flung the canvas and the
+    // engine ended up stopped/frozen with no output. Input stamps must come
+    // from the engine's own frame timeline (v5 semantics: one clock).
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_speed_percent(ctx, 300);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    const int fr_key = dasher_find_parameter_key("LP_FRAMERATE");
+    ASSERT(fr_key >= 0);
+
+    int64_t clock = 1000;
+    auto frame = [&]() {
+        dasher_mouse_move(ctx, 700.0f, 280.0f);
+        int* c = nullptr;
+        int cc = 0;
+        char** s = nullptr;
+        int sc = 0;
+        dasher_frame(ctx, clock += 20, &c, &cc, &s, &sc);
+    };
+    auto outLen = [&]() { return strlen(dasher_get_output_text(ctx)); };
+
+    // First run: types normally (same setup as the reset test).
+    dasher_mouse_down(ctx);
+    for (int i = 0; i < 300; i++) frame();
+    dasher_mouse_up(ctx);
+    const size_t len1 = outLen();
+    const long f1 = dasher_get_long_parameter(ctx, fr_key);
+    ASSERT(len1 > 0); // pre-fix: engine froze with zero output
+
+    // Stop, then restart.
+    dasher_mouse_down(ctx);
+    for (int i = 0; i < 5; i++) frame();
+    dasher_mouse_up(ctx);
+
+    dasher_mouse_down(ctx);
+    for (int i = 0; i < 4; i++) frame();
+    // Sample the restart transient: pre-fix, the first post-restart window
+    // was seeded from a steady_clock stamp and measured ~0 fps, collapsing
+    // LP_FRAMERATE to ~half (observed 4999 -> 2499) and doubling step sizes
+    // for ~10 frames — the "canvas pulls you much higher" restart fling.
+    const long f2 = dasher_get_long_parameter(ctx, fr_key);
+    for (int i = 0; i < 146; i++) frame();
+    dasher_mouse_up(ctx);
+    const size_t len2 = outLen();
+
+    printf("  run1: len=%zu FR=%ld  restart@4: FR=%ld len=%zu\n", len1, f1, f2, len2);
+
+    // Post-restart the engine keeps typing at the same measured rate.
+    ASSERT(len2 > len1);
+    ASSERT(f2 >= f1 - f1 / 10);
+
+    dasher_destroy(ctx);
+}
+
 TEST(create_with_fresh_user_dir_regex_hazard_path) {
     // Regression: XmlSettingsStore::Load() passes the settings file's
     // absolute path to ScanFiles(); when the file does not exist yet


### PR DESCRIPTION
﻿## Summary

Fixes the restart drift reported on **Windows and Android** (#60): "as soon as you lift your finger/pointer and start zooming again, the canvas pulls you up much higher than you want… the more times you restart, the worse the tracking drift gets."

### Root cause

`dasher_frame` runs on the **frontend's timeline**; `dasher_mouse_down/up` / `dasher_key_event` stamped their KeyDown/KeyUp with an internal **steady_clock** reading. The engine subtracts input stamps from frame times as one clock:

- `run()` (the start toggle) seeds the framerate sample window (`Reset_framerate`) and the slow-start clock from the input stamp;
- the next `RecordFrame` on the frame timeline computed a garbage window delta → `LP_FRAMERATE` (50:50 decaying average) collapsed → `m_iSteps` went wrong (toward 1, where `ScheduleOneStep` computes `frac = 1.0` — a **full-distance jump in one frame**).

Measured in the regression test (pre-fix): `LP_FRAMERATE 4999 → 2499` two frames after **every** restart, recovering over ~10 frames — a dynamics glitch per restart, compounding with repeated restarts. v5 was immune because its frontends embedded the engine on one clock. Any v6 frontend whose frame timeline differs from steady_clock is affected (Windows, Android); frontends passing steady-monotonic stamps happened to look fine.

### Fix

Input events are stamped from `dasher_ctx::lastFrameMs` (updated by every `dasher_frame`) — one clock, v5 semantics, **no frontend changes required**. The `mouseDown`-guard early-outs (`dasher_set_alphabet_id`, `dasher_set_palette` releasing a stuck button) are switched to the same stamp.

### Regression test

`restart_keeps_typing_after_stop_start_cycle` (test_capi_extended.cpp): type → stop → restart → `LP_FRAMERATE` sampled 4 frames after the restart must be within 10% of pre-stop (pre-fix: 2499 vs 4999 → fails; post-fix: flat) and output must keep growing. Verified fail-then-pass locally on the full matrix configuration (Debug, MSVC, CI-parity CMake).

### Disproven theories (documented on #60 for the record)

- pause leaving a zoom "ramp" draining (`ScheduleOneStep` enqueues one entry per frame; canvas is static after stop);
- `BP_STOP_OUTSIDE` default flipped vs v5 (legacy repo confirms v5 default is also `false`).

Fixes #60






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves C API input events onto the host-provided frame timeline and adds a restart regression test. The follow-up timestamp cap still leaves conflicting timing failures:
- Bursts beyond three transitions collapse onto one timestamp.
- A subsequent frame advancing by less than two milliseconds can remain behind the synthetic input time.

<h3>Confidence Score: 3/5</h3>

The PR does not yet appear safe to merge because supported input sequences can still collapse gesture timestamps, while slowly advancing frame timestamps can trigger unsigned elapsed-time underflow.

The prior reply shown without an author says intra-frame ordering was fixed, but the current cap provides a concrete residual counterexample: the fourth transition retains the third transition’s timestamp. Independently, stamps up to two milliseconds beyond the latest frame can exceed the next legal frame timestamp, causing slow-start and hold calculations to underflow.

**Files Needing Attention:** src/CAPI.cpp

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/CAPI.cpp | Moves input events to the frame timeline, but the capped synthetic increments still permit both timestamp collisions and input stamps ahead of subsequent frames. |
| tests/test_capi_extended.cpp | Adds useful restart and frame-rate regression coverage, but does not exercise rapid same-frame transitions or repeated and one-millisecond frame timestamps. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant H as Host
  participant C as C API
  participant F as Input filter
  H->>C: dasher_frame(T)
  H->>C: input transitions
  C->>F: T, T+1, T+2, T+2...
  H->>C: dasher_frame(T or T+1)
  C->>F: frame timestamp behind synthetic input
  Note over F: Collapsed gesture timing or unsigned elapsed-time underflow
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(capi): cap intra-frame input stamps ..."](https://github.com/dasher-project/dashercore/commit/a0cdab4f722b53571fb67e4f5ddfd1c09d7590bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56962864)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Input filters and start handlers](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/input-filters-and-start-handlers.md)
- Knowledge Base — [Model, view, and rendering geometry](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/model-view-rendering.md)
- Knowledge Base — [C API and host integration](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/c-api-and-host-integration.md)
</details>


<!-- /greptile_comment -->