### PR TITLE
fix(colours): letter-family group boxes lost their palette colours (uppercase distinctly coloured again)

### DIFF
--- a/src/DasherCore/ColorIO.cpp
+++ b/src/DasherCore/ColorIO.cpp
@@ -110,7 +110,12 @@ bool CColorIO::ParseLegacy(pugi::xml_document& document) {
         }
 
         // Letter groups: 10-109, alt: 140-239
-        // Map all common colorInfoName values used by alphabets
+        // Restore group-box colours (#62): v5 gave each letter-family group
+        // a distinct palette index and v6's maintained palettes continue
+        // that design (uppercase yellow, punctuation green, numbers red =
+        // legacy indices 111/112/113 = the new-format files' groupColor
+        // values). ParseLegacy never set any group colour, so legacy
+        // palettes rendered all letter families identically.
         {
             ColorPalette::GroupColorInfo letterGroup;
             for (int i = 10; i < 110 && i < (int)colors.size(); i++)
@@ -121,28 +126,38 @@ bool CColorIO::ParseLegacy(pugi::xml_document& document) {
             letterGroup.nodeLabelColorSequence = {NamedColors[NamedColor::defaultLabel]};
             letterGroup.groupOutlineColor = {NamedColors[NamedColor::defaultOutline], ColorPalette::undefinedColor};
             letterGroup.groupLabelColor = {NamedColors[NamedColor::defaultLabel], ColorPalette::undefinedColor};
+            letterGroup.groupColor.first = safeColor(0); // v5: lowercase group box
+            GroupColors["lowercase"] = letterGroup;
+            GroupColors["lower case letters"] = letterGroup;
+            GroupColors["Lower case Latin letters"] = letterGroup;
 
-            std::vector<std::string> letterGroupNames = {
-                "lowercase",
-                "lower case letters",
-                "Lower case Latin letters",
-                "upper case letters",
-                "Upper case Latin letters",
-                "numbers",
-                "Numbers",
-                "punctuation",
-                "Punctuation",
-                "ethiopic letters",
-                "vowels etc",
-                "vowel signs etc",
-                "vowel-like letters",
-                "character modifiers?",
-                "hamza",
-                "joiners",
-                "arabic-indic numbers",
-                "ascii punctuation",
+            ColorPalette::GroupColorInfo upperGroup = letterGroup;
+            upperGroup.groupColor.first =
+                safeColor(111); // v6 palette design: uppercase group (yellow, = new-format #ffff00)
+            GroupColors["uppercase"] = upperGroup;
+            GroupColors["upper case letters"] = upperGroup;
+            GroupColors["Upper case Latin letters"] = upperGroup;
+
+            ColorPalette::GroupColorInfo punctGroup = letterGroup;
+            punctGroup.groupColor.first = safeColor(112); // v5: punctuation group box
+            GroupColors["punctuation"] = punctGroup;
+            GroupColors["Punctuation"] = punctGroup;
+            GroupColors["limitedPunctuation"] = punctGroup;
+            GroupColors["ascii punctuation"] = punctGroup;
+
+            ColorPalette::GroupColorInfo numberGroup = letterGroup;
+            numberGroup.groupColor.first = safeColor(113); // v5: numbers group box
+            GroupColors["numbers"] = numberGroup;
+            GroupColors["Numbers"] = numberGroup;
+            GroupColors["arabic-indic numbers"] = numberGroup;
+
+            // Remaining groups (scripts etc.): letter cycle, no distinct box.
+            std::vector<std::string> remainingGroupNames = {
+                "ethiopic letters",     "vowels etc", "vowel signs etc", "vowel-like letters",
+                "character modifiers?", "hamza",      "joiners",
             };
-            for (auto& name : letterGroupNames)
+            letterGroup.groupColor.first = ColorPalette::undefinedColor;
+            for (auto& name : remainingGroupNames)
                 GroupColors[name] = letterGroup;
         }
 

--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -113,8 +113,13 @@ void CDasherInterfaceBase::Realize(unsigned long ulTime) {
     }
 
     m_ColorIO = std::make_unique<CColorIO>(this);
-    Dasher::FileUtils::ScanFiles(m_ColorIO.get(), "color.*.xml");
+    // Legacy palettes first, new format second: on name collisions the
+    // maintained new-format file must win. Data/colours/colour.xml is a
+    // legacy palette also named "Default" — parsing it after color.*.xml
+    // overwrote the new Default, dropping its group colours (e.g. the
+    // distinct uppercase group box, #62).
     Dasher::FileUtils::ScanFiles(m_ColorIO.get(), "colour.*.xml");
+    Dasher::FileUtils::ScanFiles(m_ColorIO.get(), "color.*.xml");
     m_ColorIO->RelinkParents();
 
     ChangeView();

--- a/tests/test_draw_commands.cpp
+++ b/tests/test_draw_commands.cpp
@@ -257,16 +257,33 @@ TEST(uppercase_group_box_has_distinct_colour) {
     ASSERT(ctx != nullptr);
     dasher_set_screen_size(ctx, 800, 600);
 
-    auto frameHasFill = [&](int r, int g, int b) {
+    // The uppercase group's box is asserted by geometry, not colour alone:
+    // at rest the initial view's text labels are the capital letters
+    // themselves, so the "A" label must sit inside a filled rect carrying
+    // the uppercase group colour. (Colour-only would let an unrelated
+    // yellow element satisfy the assertion.)
+    auto frameHasColouredUppercaseBox = [&](int r, int g, int b) {
         int* cmds;
         int cmd_count;
         char** strs;
         int str_count;
         get_frame(ctx, 1000, &cmds, &cmd_count, &strs, &str_count);
         for (int i = 0; i + 5 < cmd_count; i += 6) {
-            if (cmds[i] != 4) continue; // filled rectangle
-            int argb = cmds[i + 5];
-            if (((argb >> 16) & 0xFF) == r && ((argb >> 8) & 0xFF) == g && (argb & 0xFF) == b) return true;
+            if (cmds[i] != 5) continue; // text
+            const int sidx = cmds[i + 4];
+            if (sidx < 0 || sidx >= str_count) continue;
+            if (strcmp(strs[sidx], "A") != 0) continue;
+            const int tx = cmds[i + 1], ty = cmds[i + 2];
+            for (int j = 0; j + 5 < cmd_count; j += 6) {
+                if (cmds[j] != 4) continue; // filled rectangle
+                const int argb = cmds[j + 5];
+                if (((argb >> 16) & 0xFF) != r || ((argb >> 8) & 0xFF) != g || (argb & 0xFF) != b) continue;
+                const int x1 = cmds[j + 1] < cmds[j + 3] ? cmds[j + 1] : cmds[j + 3];
+                const int x2 = cmds[j + 1] < cmds[j + 3] ? cmds[j + 3] : cmds[j + 1];
+                const int y1 = cmds[j + 2] < cmds[j + 4] ? cmds[j + 2] : cmds[j + 4];
+                const int y2 = cmds[j + 2] < cmds[j + 4] ? cmds[j + 4] : cmds[j + 2];
+                if (tx >= x1 && tx <= x2 && ty >= y1 && ty <= y2) return true;
+            }
         }
         return false;
     };
@@ -276,7 +293,7 @@ TEST(uppercase_group_box_has_distinct_colour) {
 
     // Default palette: uppercase group box = #FFFF00 (from color.default.xml,
     // which must survive the legacy colour.xml name collision).
-    ASSERT(frameHasFill(255, 255, 0));
+    ASSERT(frameHasColouredUppercaseBox(255, 255, 0));
 
     // Legacy palette: same group colour via the legacy indices —
     // ParseLegacy must set the letter-family group colours.
@@ -284,7 +301,7 @@ TEST(uppercase_group_box_has_distinct_colour) {
     ASSERT(colourKey >= 0);
     dasher_set_string_parameter(ctx, colourKey, "European/Asian (Original)");
     run_frames(ctx, 30);
-    ASSERT(frameHasFill(255, 255, 0));
+    ASSERT(frameHasColouredUppercaseBox(255, 255, 0));
 
     dasher_destroy(ctx);
 }

--- a/tests/test_draw_commands.cpp
+++ b/tests/test_draw_commands.cpp
@@ -243,3 +243,48 @@ TEST(draw_no_mouse_produces_idle_frame) {
 
     dasher_destroy(ctx);
 }
+
+TEST(uppercase_group_box_has_distinct_colour) {
+    // Regression (#62 — "v5 put capitals in a separate, uniquely colored
+    // node"): the uppercase group box must render with its palette group
+    // colour. Two failures conspired: legacy colour.*.xml files parsed AFTER
+    // the new-format color.*.xml files, and Data/colours/colour.xml is a
+    // legacy palette also named "Default" — it overwrote the new Default and
+    // dropped its group colours (uppercase #FFFF00). And the legacy parser
+    // itself never set letter-family group colours, so legacy palettes lost
+    // v5's uppercase pink (palette index 111 = #FF80FF).
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    auto frameHasFill = [&](int r, int g, int b) {
+        int* cmds;
+        int cmd_count;
+        char** strs;
+        int str_count;
+        get_frame(ctx, 1000, &cmds, &cmd_count, &strs, &str_count);
+        for (int i = 0; i + 5 < cmd_count; i += 6) {
+            if (cmds[i] != 4) continue; // filled rectangle
+            int argb = cmds[i + 5];
+            if (((argb >> 16) & 0xFF) == r && ((argb >> 8) & 0xFF) == g && (argb & 0xFF) == b) return true;
+        }
+        return false;
+    };
+
+    // Warm up so the initial tree is fully expanded.
+    run_frames(ctx, 30);
+
+    // Default palette: uppercase group box = #FFFF00 (from color.default.xml,
+    // which must survive the legacy colour.xml name collision).
+    ASSERT(frameHasFill(255, 255, 0));
+
+    // Legacy palette: same group colour via the legacy indices —
+    // ParseLegacy must set the letter-family group colours.
+    const int colourKey = dasher_find_parameter_key("SP_COLOUR_ID");
+    ASSERT(colourKey >= 0);
+    dasher_set_string_parameter(ctx, colourKey, "European/Asian (Original)");
+    run_frames(ctx, 30);
+    ASSERT(frameHasFill(255, 255, 0));
+
+    dasher_destroy(ctx);
+}


### PR DESCRIPTION
﻿## Summary

Fixes #62 — the v5-parity report: *"In v5, [capitals] were placed in a separate, uniquely colored node, which made them much easier to spot and target quickly."* The separate group node survived; its **colour** did not.

Investigation traced it with a frame-command colour probe (scan `dasher_frame` output for filled-rect RGB per palette), which found **two compounding causes**:

### 1. Load-order clobber (hits every default-palette user)

`DasherInterfaceBase` parsed new-format `color.*.xml` **before** legacy `colour.*.xml` — and `Data/colours/colour.xml` is a legacy palette also named **"Default"**. `ParseLegacy` overwrote `KnownPalettes["Default"]`, destroying the new-format Default that defines `uppercase groupColor="#ffff00"`. Probe, pre-fix: on **Default** no group box rendered with any palette fill at all; on **European/Asian** the yellow uppercase box rendered fine.

### 2. Legacy parser never set letter-family group colours

`ParseLegacy` mapped every letter-family `colorInfoName` to one shared `GroupColorInfo` with **no `groupColor`**, and its key list missed the bare `"uppercase"` / `"limitedPunctuation"` names the alphabet files actually use — so legacy palettes rendered all letter families identically.

### Fix

- Legacy files parse **first**; the maintained new format wins name collisions.
- `ParseLegacy` restores group colours per v6's palette design: lowercase `0` / uppercase `111` (yellow) / punctuation `112` (green) / numbers `113` (red) — legacy indices that **exactly match** the new-format files' `groupColor` values (verified against the parsed palettes; v5's own file had pink there, but v6's maintained palettes deliberately chose yellow/green/red, so the fix makes both formats consistent).

### Result (probe-verified)

| palette | uppercase group box |
|---|---|
| Default | none → **#FFFF00** |
| European/Asian (Original) (legacy) | none → **#FFFF00** |
| European/Asian (new) | #FFFF00 (unchanged) |

Capitals now sit in a distinctly coloured group box on every palette — the v5 behaviour restored under v6's colour design.

### Test

`uppercase_group_box_has_distinct_colour` (test_draw_commands.cpp): renders frames and asserts the uppercase group's fill colour on both the Default palette (post-clobber) and a legacy palette — verified failing pre-fix, passing post-fix. Local matrix suite green (capi 10, extended 17, draw 9, parameters 13, settings 7, color-math 14).

Fixes #62




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores distinct letter-family group-box colors across modern and legacy palettes and ensures maintained modern palettes win name collisions.
- Loads legacy `colour.*.xml` files before modern `color.*.xml` files.
- Assigns legacy group colors for lowercase, uppercase, punctuation, and number families.
- Adds regression coverage for uppercase group coloring in both default and legacy palettes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/DasherCore/ColorIO.cpp | Adds distinct legacy group-box colors and aliases for the letter-family names used by alphabet definitions. |
| src/DasherCore/DasherInterfaceBase.cpp | Reorders palette discovery so maintained modern definitions override colliding legacy palette names. |
| tests/test_draw_commands.cpp | Adds command-stream regression coverage tying the expected uppercase color to the geometry containing the capital “A” label. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: tie uppercase-box assertion to geo..."](https://github.com/dasher-project/dashercore/commit/ca215a1bccc6ea877cda5f2a51692ae2a065b1ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56994268)</sub>

<!-- /greptile_comment -->