### PR TITLE
fix(alphabets): paragraph symbol outputs newline, not the pilcrow

### DIFF
--- a/Data/alphabets/alphabet.deutsch.german.with.limited.punctuation.xml
+++ b/Data/alphabets/alphabet.deutsch.german.with.limited.punctuation.xml
@@ -203,7 +203,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/Data/alphabets/alphabet.deutsch.german.with.numerals.and.punctuation.xml
+++ b/Data/alphabets/alphabet.deutsch.german.with.numerals.and.punctuation.xml
@@ -455,7 +455,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/Data/alphabets/alphabet.english.latex.xml
+++ b/Data/alphabets/alphabet.english.latex.xml
@@ -389,7 +389,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/Data/alphabets/alphabet.english.with.accents.numerals.punctuation.xml
+++ b/Data/alphabets/alphabet.english.with.accents.numerals.punctuation.xml
@@ -490,7 +490,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/Data/alphabets/alphabet.english.with.limited.punctuation.xml
+++ b/Data/alphabets/alphabet.english.with.limited.punctuation.xml
@@ -252,7 +252,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/Data/alphabets/alphabet.english.with.numerals.and.limited.punctuation.xml
+++ b/Data/alphabets/alphabet.english.with.numerals.and.limited.punctuation.xml
@@ -290,7 +290,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/Data/alphabets/alphabet.english.with.numerals.and.lots.of.punctuation.xml
+++ b/Data/alphabets/alphabet.english.with.numerals.and.lots.of.punctuation.xml
@@ -427,7 +427,7 @@
 		</node>
 	</group>
 	<group name="paragraphSpace" colorInfoName="paragraphSpace">
-		<node label="¶">
+		<node label="¶" text="&#10;">
 			<!--Old Char Color: 9-->
 			<textCharAction />
 		</node>

--- a/tests/test_alphabet_xml.cpp
+++ b/tests/test_alphabet_xml.cpp
@@ -194,6 +194,48 @@ TEST(alphabet_v6_space_character_resolves_to_space) {
     dasher_destroy(ctx);
 }
 
+// The paragraph symbol (display "pilcrow") in the shipped v6 alphabets must
+// OUTPUT a newline, not the display character. The v5->v6 conversion of the
+// hand-written v6 files lost the output char, leaving an empty
+// <textCharAction/> so the pilcrow was inserted literally (reported as
+// "return just shows a paragraph symbol"). Regression test for that fix.
+TEST(alphabet_v6_paragraph_outputs_newline) {
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    const char* alphabets_to_check[] = {
+        "English with numerals and limited punctuation",
+        "English with limited punctuation",
+        "English with numerals and lots of punctuation",
+        "English with accents, numerals, punctuation",
+        "German with numerals and punctuation",
+    };
+
+    for (const char* alph : alphabets_to_check) {
+        dasher_set_alphabet_id(ctx, alph);
+        int sym_count = dasher_get_alphabet_symbol_count(ctx);
+        ASSERT(sym_count > 0);
+
+        bool found_paragraph_display = false, paragraph_is_newline = false;
+        for (int i = 1; i <= sym_count; i++) {
+            char disp[128], text[128];
+            if (dasher_get_alphabet_symbol_display(ctx, i, disp, sizeof(disp)) != 0) continue;
+            if (strcmp(disp, "\xc2\xb6") != 0) continue; // UTF-8 pilcrow
+            found_paragraph_display = true;
+            if (dasher_get_alphabet_symbol_text(ctx, i, text, sizeof(text)) == 0
+                && strcmp(text, "\n") == 0)
+                paragraph_is_newline = true;
+        }
+        printf("  %s: paragraph display found=%d outputs_newline=%d\n",
+               alph, found_paragraph_display, paragraph_is_newline);
+        ASSERT(found_paragraph_display);
+        ASSERT(paragraph_is_newline);
+    }
+
+    dasher_destroy(ctx);
+}
+
 // A v5-format alphabet (root <alphabets>, <s> symbols, <train> child element)
 // must load and appear in the alphabet list alongside the bundled v6 files.
 TEST(alphabet_v5_format_loads) {

--- a/tests/test_alphabet_xml.cpp
+++ b/tests/test_alphabet_xml.cpp
@@ -204,16 +204,24 @@ TEST(alphabet_v6_paragraph_outputs_newline) {
     ASSERT(ctx);
     dasher_set_screen_size(ctx, 800, 600);
 
+    // Every shipped v6 alphabet that carries a paragraphSpace group.
+    // Names must match the <alphabet name="..."> attribute exactly: an
+    // unknown name silently falls back to the default alphabet, which
+    // would make the check pass without testing the resource.
     const char* alphabets_to_check[] = {
         "English with numerals and limited punctuation",
         "English with limited punctuation",
         "English with numerals and lots of punctuation",
         "English with accents, numerals, punctuation",
-        "German with numerals and punctuation",
+        "English Latex",
+        "Deutsch / German with limited punctuation",
+        "Deutsch / German with numerals and punctuation",
     };
 
     for (const char* alph : alphabets_to_check) {
         dasher_set_alphabet_id(ctx, alph);
+        ASSERT_STR_EQ(dasher_get_alphabet_id(ctx), alph);
+
         int sym_count = dasher_get_alphabet_symbol_count(ctx);
         ASSERT(sym_count > 0);
 
@@ -223,12 +231,11 @@ TEST(alphabet_v6_paragraph_outputs_newline) {
             if (dasher_get_alphabet_symbol_display(ctx, i, disp, sizeof(disp)) != 0) continue;
             if (strcmp(disp, "\xc2\xb6") != 0) continue; // UTF-8 pilcrow
             found_paragraph_display = true;
-            if (dasher_get_alphabet_symbol_text(ctx, i, text, sizeof(text)) == 0
-                && strcmp(text, "\n") == 0)
+            if (dasher_get_alphabet_symbol_text(ctx, i, text, sizeof(text)) == 0 && strcmp(text, "\n") == 0)
                 paragraph_is_newline = true;
         }
-        printf("  %s: paragraph display found=%d outputs_newline=%d\n",
-               alph, found_paragraph_display, paragraph_is_newline);
+        printf("  %s: paragraph display found=%d outputs_newline=%d\n", alph, found_paragraph_display,
+               paragraph_is_newline);
         ASSERT(found_paragraph_display);
         ASSERT(paragraph_is_newline);
     }


### PR DESCRIPTION
## Summary

User report: 'The return function is not working, it just shows a paragraph symbol.'

The seven hand-written v6 alphabets' paragraphSpace group had an empty textCharAction on the paragraph node — the v5-to-v6 conversion lost the output character, so the parser fell back to outputting the node's display label. Pressing return inserted a literal pilcrow instead of a line break.

## Changes
- Restore text LF on the paragraph node in all 7 shipped v6 alphabets (English x5, German x2), matching the engine's own autoConverted convention
- Regression test: alphabet_v6_paragraph_outputs_newline asserts every shipped paragraph symbol outputs \n across 5 alphabets

## Verification
dasher_alphabet_xml_tests: 14/14 test cases, 72/72 assertions green.

## Type of change
- [x] Bug fix



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores newline output for the paragraph symbol in seven shipped v6 alphabets and adds regression coverage across those resources.
- Adds explicit line-feed output text to each affected paragraph node.
- Corrects the German alphabet identifier in the regression test and verifies all listed alphabets expose a pilcrow that maps to `\n`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/test_alphabet_xml.cpp | Adds cross-alphabet paragraph-output coverage and corrects the previously invalid German alphabet name. |
| Data/alphabets/alphabet.deutsch.german.with.limited.punctuation.xml | Maps the displayed paragraph symbol to a line feed. |
| Data/alphabets/alphabet.deutsch.german.with.numerals.and.punctuation.xml | Maps the displayed paragraph symbol to a line feed. |
| Data/alphabets/alphabet.english.latex.xml | Maps the displayed paragraph symbol to a line feed. |
| Data/alphabets/alphabet.english.with.accents.numerals.punctuation.xml | Maps the displayed paragraph symbol to a line feed. |
| Data/alphabets/alphabet.english.with.limited.punctuation.xml | Maps the displayed paragraph symbol to a line feed. |
| Data/alphabets/alphabet.english.with.numerals.and.limited.punctuation.xml | Maps the displayed paragraph symbol to a line feed. |
| Data/alphabets/alphabet.english.with.numerals.and.lots.of.punctuation.xml | Maps the displayed paragraph symbol to a line feed. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test): exact alphabet names + clang-..."](https://github.com/dasher-project/dashercore/commit/938b0d4c008a53cc8ed86d1162076c87b9a868a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57556890)</sub>

**Context used:**

- Knowledge Base — [Alphabet configuration and managers](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/alphabet-configuration-and-managers.md)

<!-- /greptile_comment -->