### PR TITLE
feat(capi): dasher_reload_settings — re-read settings and apply changes

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -1693,6 +1693,23 @@ DASHER_API void dasher_save_settings(dasher_ctx* ctx) {
     if (ctx->appearanceLoaded) saveAppearanceSettings(ctx); // RFC 0007 sidecar
 }
 
+DASHER_API void dasher_reload_settings(dasher_ctx* ctx) {
+    if (!ctx || !ctx->settings) return;
+    try {
+        // Re-read dasher_settings.xml and apply changes through the normal
+        // parameter path — fires OnParameterChanged so the engine rebuilds
+        // derived state (alphabet, colours, input filter) and the frontend
+        // callback notifies. Safe to call any time; only differing values
+        // are applied. Use cases: settings file changed externally (IME
+        // service shared directory, migration, another process).
+        ctx->settings->ReloadFromFile();
+    } catch (const std::exception& e) {
+        log_boundary_error(ctx, "dasher_reload_settings", e.what());
+    } catch (...) {
+        log_boundary_error(ctx, "dasher_reload_settings", "unknown exception");
+    }
+}
+
 // Reset every parameter to its built-in default value (from Parameters.h).
 // Routes through the typed Set*Parameter methods so the normal parameter-change
 // notifications fire and a live engine reconfigures itself (alphabet/colour/LM

--- a/src/DasherCore/SettingsStore.cpp
+++ b/src/DasherCore/SettingsStore.cpp
@@ -70,6 +70,13 @@ void CSettingsStore::LoadPersistent() {
     AddParameters(Settings::parameter_defaults);
 }
 
+Settings::ParameterType CSettingsStore::TypeForStorageName(const std::string& name) const {
+    for (const auto& [key, value] : parameters_) {
+        if (value.storageName == name) return value.type;
+    }
+    return Settings::PARAM_INVALID;
+}
+
 void CSettingsStore::AddParameters(const std::unordered_map<Parameter, const Settings::Parameter_Value> table) {
 
     for (const auto& [key, value] : table) {

--- a/src/DasherCore/SettingsStore.cpp
+++ b/src/DasherCore/SettingsStore.cpp
@@ -15,6 +15,55 @@ using namespace Dasher;
 
 CSettingsStore::CSettingsStore() {}
 
+void CSettingsStore::ReloadFromFile() {
+    // Re-read the persistent settings from the backing store and apply any
+    // differences through SetParameter — the same path the settings UI uses —
+    // so parameter-change handlers fire, the engine rebuilds derived state,
+    // and the frontend callback notifies.
+
+    // Snapshot the current values so we only apply real changes.
+    std::unordered_map<Parameter, std::variant<bool, long, std::string>> current;
+    for (const auto& [key, value] : parameters_) {
+        current[key] = value.value;
+    }
+
+    // Re-read from the store. Subclasses override RefreshFromStore() to
+    // re-parse the backing file (XmlSettingsStore re-scans the XML), then
+    // repopulate parameters_ in place.
+    RefreshFromStore();
+
+    // Now diff and apply through SetParameter for anything that changed.
+    // RefreshFromStore already wrote the new file values into parameters_,
+    // so we need to temporarily restore the old value before calling
+    // SetParameter with the new one — otherwise SetParameter's "nothing
+    // changed" early-return would skip the OnParameterChanged broadcast.
+    for (auto& [key, value] : parameters_) {
+        const auto it = current.find(key);
+        if (it == current.end()) continue;
+        if (value.value == it->second) continue;
+
+        // Save the new (from-file) value, restore the old one so
+        // SetParameter detects a real change and fires notifications.
+        const auto new_value = value.value;
+        value.value = it->second;
+
+        if (std::holds_alternative<bool>(new_value)) {
+            SetBoolParameter(key, std::get<bool>(new_value));
+        } else if (std::holds_alternative<long>(new_value)) {
+            SetLongParameter(key, std::get<long>(new_value));
+        } else if (std::holds_alternative<std::string>(new_value)) {
+            SetStringParameter(key, std::get<std::string>(new_value));
+        }
+    }
+}
+
+void CSettingsStore::RefreshFromStore() {
+    // Base implementation: re-read from the in-memory settings maps.
+    // Subclasses with a file-backed store (XmlSettingsStore) override this
+    // to re-parse the file first.
+    LoadPersistent();
+}
+
 void CSettingsStore::LoadPersistent() {
     // Load each of the persistent parameters.  If we fail loading for the store, then
     // we'll save the settings with the default value that comes from Parameters.h

--- a/src/DasherCore/SettingsStore.h
+++ b/src/DasherCore/SettingsStore.h
@@ -63,6 +63,20 @@ class CSettingsStore {
     // TODO: just load the application parameters by default?
     void AddParameters(const std::unordered_map<Parameter, const Settings::Parameter_Value> table);
 
+    /// Re-read the settings file and apply any changed values through the
+    /// normal SetParameter path (fires OnParameterChanged, triggers the
+    /// engine's per-parameter handlers, updates the frontend callback).
+    /// Only parameters whose file value differs from the current value are
+    /// applied — no spurious rebuilds. The edit buffer and model state
+    /// are preserved.
+    void ReloadFromFile();
+
+    /// Re-read the settings backing store and repopulate parameters_ in
+    /// place. Base implementation re-reads from the in-memory maps;
+    /// file-backed subclasses (XmlSettingsStore) override to re-parse the
+    /// file first.
+    virtual void RefreshFromStore();
+
     Event<Parameter, std::variant<bool, long, std::string>> OnPreParameterChange;
     Event<Parameter> OnParameterChanged;
 

--- a/src/DasherCore/SettingsStore.h
+++ b/src/DasherCore/SettingsStore.h
@@ -87,6 +87,13 @@ class CSettingsStore {
     ///  existing value stored; non-persistent prefs are reinitialized from defaults.
     void LoadPersistent();
 
+    /// Look up the declared type for a storage name. Returns PARAM_INVALID
+    /// when the name is not a registered parameter (a stale key from an
+    /// older build — harmless, callers allow it). Used by file-backed
+    /// stores to validate that an entry's tag matches the parameter's
+    /// declared type.
+    Settings::ParameterType TypeForStorageName(const std::string& name) const;
+
   private:
     // Platform Specific settings file management
 

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -18,6 +18,15 @@ XmlSettingsStore::XmlSettingsStore(const std::string& filename, CMessageDisplay*
     : AbstractXMLParser(pDisplay), last_mutable_filepath(filename) {}
 
 void XmlSettingsStore::RefreshFromStore() {
+    // Save the current parsed maps so we can restore them if the file is
+    // missing, unreadable, or malformed — clearing upfront and parsing into
+    // nothing would make LoadPersistent treat every persistent setting as
+    // removed and reset the running engine to defaults (mass callbacks and
+    // rebuilds for what is a transient I/O problem, not a real removal).
+    const auto saved_bool = boolean_settings_;
+    const auto saved_long = long_settings_;
+    const auto saved_string = string_settings_;
+
     // Clear the parsed maps so entries removed from the file are actually
     // removed (Parse only inserts/overwrites — stale keys would survive a
     // re-parse and LoadPersistent would treat them as still present,
@@ -30,7 +39,25 @@ void XmlSettingsStore::RefreshFromStore() {
     // parameters_ from those maps (same path Load() uses, but without
     // the mode switching). The parse overwrites the maps in place;
     // LoadPersistent then updates parameters_ entries from them.
+    // reload_parse_ok_ is set by Parse() — it is only reached when the
+    // document actually loaded (missing/unreadable/malformed files fail
+    // earlier), which distinguishes a real empty-file removal from an
+    // I/O failure.
+    reload_parse_ok_ = false;
     Dasher::FileUtils::ScanFiles(this, last_mutable_filepath);
+
+    // If the file didn't parse (missing/unreadable/malformed), keep the
+    // previous state entirely — maps AND parameters. A transient I/O
+    // problem must not reset the running engine to defaults, so skip
+    // LoadPersistent too: ReloadFromFile's diff then sees no change and
+    // emits no notifications.
+    if (!reload_parse_ok_) {
+        boolean_settings_ = saved_bool;
+        long_settings_ = saved_long;
+        string_settings_ = saved_string;
+        return;
+    }
+
     mode_ = EXPLICIT_SAVE;
     LoadPersistent();
     mode_ = SAVE_IMMEDIATELY;
@@ -120,6 +147,7 @@ bool XmlSettingsStore::Save() {
 
 bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string filePath, bool bUser) {
     if (bUser) last_mutable_filepath = filePath;
+    reload_parse_ok_ = true; // reached only when the document loaded
 
     const pugi::xml_node outer = document.child("settings");
     for (pugi::xml_node bool_setting : outer.children("bool")) {

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -2,6 +2,9 @@
 #include "DasherInterfaceBase.h"
 #include "FileUtils.h"
 
+#include <cctype>
+#include <cstdlib>
+
 namespace Dasher {
 
 template <typename T>
@@ -146,35 +149,33 @@ bool XmlSettingsStore::Save() {
 }
 
 namespace {
-// A bool value is valid when its first char selects an unambiguous
-// true/false in pugixml's own terms (1/0, t/f, y/n, either case);
-// anything else ("banana") would silently become false.
+// A bool value must be exactly one of pugixml's read-side tokens
+// (true/false, yes/no, 1/0 — Dasher writes "true"/"false"). A valid
+// prefix followed by junk ("truejunk") must not pass: as_bool() only
+// looks at the first character and would silently read it as true.
 bool valid_bool_value(const char* text) {
-    if (text == nullptr || *text == '\0') return false;
-    switch (*text) {
-    case '1':
-    case '0':
-    case 't':
-    case 'T':
-    case 'f':
-    case 'F':
-    case 'y':
-    case 'Y':
-    case 'n':
-    case 'N':
-        return true;
-    default:
-        return false;
+    if (text == nullptr) return false;
+    std::string token;
+    while (*text != '\0') {
+        token.push_back(static_cast<char>(tolower(static_cast<unsigned char>(*text))));
+        ++text;
     }
+    return token == "true" || token == "false" || token == "yes" || token == "no" || token == "1" || token == "0";
 }
 
-// A long value is valid when it holds at least one digit where strtoll
-// expects it ("560", " 12 ") — as_llong would return 0 for garbage.
+// A long value must parse completely: digits where strtol expects them
+// and nothing but whitespace after ("560" ok, " 12 " ok, "12junk" not —
+// as_llong() would silently return the 12 prefix).
 bool valid_long_value(const char* text) {
-    if (text == nullptr) return false;
+    if (text == nullptr || *text == '\0') return false;
     char* end = nullptr;
     strtol(text, &end, 10);
-    return end != text; // at least one digit consumed
+    if (end == text) return false; // no digits consumed
+    while (*end != '\0') {
+        if (isspace(static_cast<unsigned char>(*end)) == 0) return false;
+        ++end;
+    }
+    return true;
 }
 } // namespace
 
@@ -193,27 +194,25 @@ bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string fil
 
     // Entries with a missing or unparseable value attribute, a missing or
     // empty name, or a known parameter name under the wrong tag type are
-    // treated as corruption (e.g. a partial write): reject the whole file
-    // rather than letting a zero/false/empty value silently change the
-    // live parameter, or letting a mistyped entry drop the setting into
-    // a map LoadPersistent never reads (resetting it to default).
-    // A deliberate removal omits the element entirely. Unknown names
-    // (stale keys from older builds) are still allowed.
+    // treated as corruption: on reload the whole file is rejected (keep
+    // current state). Invalid entries are skipped without aborting the
+    // scan so the initial Load() still picks up every valid entry
+    // regardless of document order — stopping at the first bad entry
+    // made later settings initialize from defaults. A deliberate removal
+    // omits the element entirely. Unknown names (stale keys from older
+    // builds) are still allowed.
+    bool all_valid = true;
     for (pugi::xml_node bool_setting : outer.children("bool")) {
         const std::string name = bool_setting.attribute("name").as_string();
         const pugi::xml_attribute value_attr = bool_setting.attribute("value");
-        if (name.empty()) {
-            reload_parse_ok_ = false;
-            return false;
-        }
-        if (!value_attr || !valid_bool_value(value_attr.value())) {
-            reload_parse_ok_ = false;
-            return false;
+        if (name.empty() || !value_attr || !valid_bool_value(value_attr.value())) {
+            all_valid = false;
+            continue;
         }
         const auto declared = TypeForStorageName(name);
         if (declared != Settings::PARAM_INVALID && declared != Settings::PARAM_BOOL) {
-            reload_parse_ok_ = false;
-            return false;
+            all_valid = false;
+            continue;
         }
         boolean_settings_[name] = value_attr.as_bool();
     }
@@ -221,18 +220,14 @@ bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string fil
     for (pugi::xml_node string_setting : outer.children("string")) {
         const std::string name = string_setting.attribute("name").as_string();
         const pugi::xml_attribute value_attr = string_setting.attribute("value");
-        if (name.empty()) {
-            reload_parse_ok_ = false;
-            return false;
-        }
-        if (!value_attr) {
-            reload_parse_ok_ = false;
-            return false;
+        if (name.empty() || !value_attr) {
+            all_valid = false;
+            continue;
         }
         const auto declared = TypeForStorageName(name);
         if (declared != Settings::PARAM_INVALID && declared != Settings::PARAM_STRING) {
-            reload_parse_ok_ = false;
-            return false;
+            all_valid = false;
+            continue;
         }
         string_settings_[name] = value_attr.as_string();
     }
@@ -240,24 +235,19 @@ bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string fil
     for (pugi::xml_node long_setting : outer.children("long")) {
         const std::string name = long_setting.attribute("name").as_string();
         const pugi::xml_attribute value_attr = long_setting.attribute("value");
-        if (name.empty()) {
-            reload_parse_ok_ = false;
-            return false;
-        }
-        if (!value_attr || !valid_long_value(value_attr.value())) {
-            reload_parse_ok_ = false;
-            return false;
+        if (name.empty() || !value_attr || !valid_long_value(value_attr.value())) {
+            all_valid = false;
+            continue;
         }
         const auto declared = TypeForStorageName(name);
         if (declared != Settings::PARAM_INVALID && declared != Settings::PARAM_LONG) {
-            reload_parse_ok_ = false;
-            return false;
+            all_valid = false;
+            continue;
         }
         long_settings_[name] = static_cast<long>(value_attr.as_llong());
     }
 
-    reload_parse_ok_ = true; // reached only when the document loaded and validated
-
-    return true;
+    reload_parse_ok_ = all_valid;
+    return all_valid;
 }
 } // namespace Dasher

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -3,6 +3,7 @@
 #include "FileUtils.h"
 
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
 
 namespace Dasher {
@@ -163,14 +164,19 @@ bool valid_bool_value(const char* text) {
     return token == "true" || token == "false" || token == "yes" || token == "no" || token == "1" || token == "0";
 }
 
-// A long value must parse completely: digits where strtol expects them
-// and nothing but whitespace after ("560" ok, " 12 " ok, "12junk" not —
-// as_llong() would silently return the 12 prefix).
+// A long value must parse completely and fit: digits where strtol
+// expects them, nothing but whitespace after ("560" ok, " 12 " ok,
+// "12junk" not — as_llong() would silently return the 12 prefix), and
+// no overflow (strtol clamps out-of-range input to LONG_MAX/LONG_MIN
+// and reports ERANGE — the clamped value must not reach the live
+// setter).
 bool valid_long_value(const char* text) {
     if (text == nullptr || *text == '\0') return false;
+    errno = 0;
     char* end = nullptr;
     strtol(text, &end, 10);
     if (end == text) return false; // no digits consumed
+    if (errno == ERANGE) return false; // overflow — clamped value rejected
     while (*end != '\0') {
         if (isspace(static_cast<unsigned char>(*end)) == 0) return false;
         ++end;

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -145,9 +145,41 @@ bool XmlSettingsStore::Save() {
     return doc.save_file(last_mutable_filepath.c_str(), "\t", pugi::format_default, pugi::encoding_utf8);
 }
 
+namespace {
+// A bool value is valid when its first char selects an unambiguous
+// true/false in pugixml's own terms (1/0, t/f, y/n, either case);
+// anything else ("banana") would silently become false.
+bool valid_bool_value(const char* text) {
+    if (text == nullptr || *text == '\0') return false;
+    switch (*text) {
+    case '1':
+    case '0':
+    case 't':
+    case 'T':
+    case 'f':
+    case 'F':
+    case 'y':
+    case 'Y':
+    case 'n':
+    case 'N':
+        return true;
+    default:
+        return false;
+    }
+}
+
+// A long value is valid when it holds at least one digit where strtoll
+// expects it ("560", " 12 ") — as_llong would return 0 for garbage.
+bool valid_long_value(const char* text) {
+    if (text == nullptr) return false;
+    char* end = nullptr;
+    strtol(text, &end, 10);
+    return end != text; // at least one digit consumed
+}
+} // namespace
+
 bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string filePath, bool bUser) {
     if (bUser) last_mutable_filepath = filePath;
-
     const pugi::xml_node outer = document.child("settings");
 
     // A settings file must have a <settings> root. Well-formed XML with
@@ -158,24 +190,48 @@ bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string fil
         reload_parse_ok_ = false;
         return false;
     }
-    reload_parse_ok_ = true; // reached only when the document loaded
+
+    // Entries with a missing or unparseable value attribute are treated
+    // as corruption (e.g. a partial write): reject the whole file rather
+    // than letting a zero/false/empty value silently change the live
+    // parameter. A deliberate removal omits the element entirely.
     for (pugi::xml_node bool_setting : outer.children("bool")) {
-        std::string name = bool_setting.attribute("name").as_string();
-        const bool value = bool_setting.attribute("value").as_bool();
-        if (!name.empty()) boolean_settings_[name] = value;
+        const std::string name = bool_setting.attribute("name").as_string();
+        const pugi::xml_attribute value_attr = bool_setting.attribute("value");
+        if (!name.empty()) {
+            if (!value_attr || !valid_bool_value(value_attr.value())) {
+                reload_parse_ok_ = false;
+                return false;
+            }
+            boolean_settings_[name] = value_attr.as_bool();
+        }
     }
 
     for (pugi::xml_node string_setting : outer.children("string")) {
-        std::string name = string_setting.attribute("name").as_string();
-        const std::string value = string_setting.attribute("value").as_string();
-        if (!name.empty()) string_settings_[name] = value;
+        const std::string name = string_setting.attribute("name").as_string();
+        const pugi::xml_attribute value_attr = string_setting.attribute("value");
+        if (!name.empty()) {
+            if (!value_attr) {
+                reload_parse_ok_ = false;
+                return false;
+            }
+            string_settings_[name] = value_attr.as_string();
+        }
     }
 
     for (pugi::xml_node long_setting : outer.children("long")) {
-        std::string name = long_setting.attribute("name").as_string();
-        const long value = static_cast<long>(long_setting.attribute("value").as_llong());
-        if (!name.empty()) long_settings_[name] = value;
+        const std::string name = long_setting.attribute("name").as_string();
+        const pugi::xml_attribute value_attr = long_setting.attribute("value");
+        if (!name.empty()) {
+            if (!value_attr || !valid_long_value(value_attr.value())) {
+                reload_parse_ok_ = false;
+                return false;
+            }
+            long_settings_[name] = static_cast<long>(value_attr.as_llong());
+        }
     }
+
+    reload_parse_ok_ = true; // reached only when the document loaded and validated
 
     return true;
 }

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -191,44 +191,69 @@ bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string fil
         return false;
     }
 
-    // Entries with a missing or unparseable value attribute are treated
-    // as corruption (e.g. a partial write): reject the whole file rather
-    // than letting a zero/false/empty value silently change the live
-    // parameter. A deliberate removal omits the element entirely.
+    // Entries with a missing or unparseable value attribute, a missing or
+    // empty name, or a known parameter name under the wrong tag type are
+    // treated as corruption (e.g. a partial write): reject the whole file
+    // rather than letting a zero/false/empty value silently change the
+    // live parameter, or letting a mistyped entry drop the setting into
+    // a map LoadPersistent never reads (resetting it to default).
+    // A deliberate removal omits the element entirely. Unknown names
+    // (stale keys from older builds) are still allowed.
     for (pugi::xml_node bool_setting : outer.children("bool")) {
         const std::string name = bool_setting.attribute("name").as_string();
         const pugi::xml_attribute value_attr = bool_setting.attribute("value");
-        if (!name.empty()) {
-            if (!value_attr || !valid_bool_value(value_attr.value())) {
-                reload_parse_ok_ = false;
-                return false;
-            }
-            boolean_settings_[name] = value_attr.as_bool();
+        if (name.empty()) {
+            reload_parse_ok_ = false;
+            return false;
         }
+        if (!value_attr || !valid_bool_value(value_attr.value())) {
+            reload_parse_ok_ = false;
+            return false;
+        }
+        const auto declared = TypeForStorageName(name);
+        if (declared != Settings::PARAM_INVALID && declared != Settings::PARAM_BOOL) {
+            reload_parse_ok_ = false;
+            return false;
+        }
+        boolean_settings_[name] = value_attr.as_bool();
     }
 
     for (pugi::xml_node string_setting : outer.children("string")) {
         const std::string name = string_setting.attribute("name").as_string();
         const pugi::xml_attribute value_attr = string_setting.attribute("value");
-        if (!name.empty()) {
-            if (!value_attr) {
-                reload_parse_ok_ = false;
-                return false;
-            }
-            string_settings_[name] = value_attr.as_string();
+        if (name.empty()) {
+            reload_parse_ok_ = false;
+            return false;
         }
+        if (!value_attr) {
+            reload_parse_ok_ = false;
+            return false;
+        }
+        const auto declared = TypeForStorageName(name);
+        if (declared != Settings::PARAM_INVALID && declared != Settings::PARAM_STRING) {
+            reload_parse_ok_ = false;
+            return false;
+        }
+        string_settings_[name] = value_attr.as_string();
     }
 
     for (pugi::xml_node long_setting : outer.children("long")) {
         const std::string name = long_setting.attribute("name").as_string();
         const pugi::xml_attribute value_attr = long_setting.attribute("value");
-        if (!name.empty()) {
-            if (!value_attr || !valid_long_value(value_attr.value())) {
-                reload_parse_ok_ = false;
-                return false;
-            }
-            long_settings_[name] = static_cast<long>(value_attr.as_llong());
+        if (name.empty()) {
+            reload_parse_ok_ = false;
+            return false;
         }
+        if (!value_attr || !valid_long_value(value_attr.value())) {
+            reload_parse_ok_ = false;
+            return false;
+        }
+        const auto declared = TypeForStorageName(name);
+        if (declared != Settings::PARAM_INVALID && declared != Settings::PARAM_LONG) {
+            reload_parse_ok_ = false;
+            return false;
+        }
+        long_settings_[name] = static_cast<long>(value_attr.as_llong());
     }
 
     reload_parse_ok_ = true; // reached only when the document loaded and validated

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -147,9 +147,18 @@ bool XmlSettingsStore::Save() {
 
 bool XmlSettingsStore::Parse(pugi::xml_document& document, const std::string filePath, bool bUser) {
     if (bUser) last_mutable_filepath = filePath;
-    reload_parse_ok_ = true; // reached only when the document loaded
 
     const pugi::xml_node outer = document.child("settings");
+
+    // A settings file must have a <settings> root. Well-formed XML with
+    // any other root is not a settings file — marking the reload
+    // successful would leave the maps empty and LoadPersistent would
+    // reset the engine to defaults.
+    if (!outer) {
+        reload_parse_ok_ = false;
+        return false;
+    }
+    reload_parse_ok_ = true; // reached only when the document loaded
     for (pugi::xml_node bool_setting : outer.children("bool")) {
         std::string name = bool_setting.attribute("name").as_string();
         const bool value = bool_setting.attribute("value").as_bool();

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -18,6 +18,14 @@ XmlSettingsStore::XmlSettingsStore(const std::string& filename, CMessageDisplay*
     : AbstractXMLParser(pDisplay), last_mutable_filepath(filename) {}
 
 void XmlSettingsStore::RefreshFromStore() {
+    // Clear the parsed maps so entries removed from the file are actually
+    // removed (Parse only inserts/overwrites — stale keys would survive a
+    // re-parse and LoadPersistent would treat them as still present,
+    // keeping the old value instead of restoring the default).
+    boolean_settings_.clear();
+    long_settings_.clear();
+    string_settings_.clear();
+
     // Re-parse the XML file into the settings maps, then repopulate
     // parameters_ from those maps (same path Load() uses, but without
     // the mode switching). The parse overwrites the maps in place;

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -17,6 +17,17 @@ static bool Read(const std::map<std::string, T> values, const std::string& key, 
 XmlSettingsStore::XmlSettingsStore(const std::string& filename, CMessageDisplay* pDisplay)
     : AbstractXMLParser(pDisplay), last_mutable_filepath(filename) {}
 
+void XmlSettingsStore::RefreshFromStore() {
+    // Re-parse the XML file into the settings maps, then repopulate
+    // parameters_ from those maps (same path Load() uses, but without
+    // the mode switching). The parse overwrites the maps in place;
+    // LoadPersistent then updates parameters_ entries from them.
+    Dasher::FileUtils::ScanFiles(this, last_mutable_filepath);
+    mode_ = EXPLICIT_SAVE;
+    LoadPersistent();
+    mode_ = SAVE_IMMEDIATELY;
+}
+
 void XmlSettingsStore::Load() {
     Dasher::FileUtils::ScanFiles(this, last_mutable_filepath);
     // Load all the settings or create defaults for the ones that don't exist.

--- a/src/DasherCore/XmlSettingsStore.cpp
+++ b/src/DasherCore/XmlSettingsStore.cpp
@@ -175,7 +175,7 @@ bool valid_long_value(const char* text) {
     errno = 0;
     char* end = nullptr;
     strtol(text, &end, 10);
-    if (end == text) return false; // no digits consumed
+    if (end == text) return false;     // no digits consumed
     if (errno == ERANGE) return false; // overflow — clamped value rejected
     while (*end != '\0') {
         if (isspace(static_cast<unsigned char>(*end)) == 0) return false;

--- a/src/DasherCore/XmlSettingsStore.h
+++ b/src/DasherCore/XmlSettingsStore.h
@@ -19,6 +19,10 @@ class XmlSettingsStore : public Dasher::CSettingsStore, public AbstractXMLParser
     // Saves the XML file, returns true on success.
     bool Save();
 
+    // Re-parse the XML file and repopulate parameters_ in place.
+    // Called by ReloadFromFile() to pick up external changes.
+    void RefreshFromStore() override;
+
     bool Parse(pugi::xml_document& document, const std::string filePath, bool bUser) override;
 
   private:

--- a/src/DasherCore/XmlSettingsStore.h
+++ b/src/DasherCore/XmlSettingsStore.h
@@ -48,6 +48,9 @@ class XmlSettingsStore : public Dasher::CSettingsStore, public AbstractXMLParser
     Mode mode_ = EXPLICIT_SAVE;
     std::string last_mutable_filepath;
     bool modified_ = false;
+    // Set by Parse() during a refresh scan to record that the file
+    // actually loaded (missing/malformed files never reach Parse).
+    bool reload_parse_ok_ = false;
     std::map<std::string, bool> boolean_settings_;
     std::map<std::string, long> long_settings_;
     std::map<std::string, std::string> string_settings_;

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -329,6 +329,14 @@ DASHER_API const char* dasher_game_get_wrong_text(dasher_ctx* ctx);
 // Save current settings to disk.
 DASHER_API void dasher_save_settings(dasher_ctx* ctx);
 
+// Re-read dasher_settings.xml and apply any changed parameters through the
+// normal SetParameter path — parameter-change handlers fire (alphabet
+// rebuild, colour change, input filter switch), the frontend callback
+// notifies, and the edit buffer is preserved. Safe to call any time;
+// only differing values are applied. Use when the settings file changed
+// externally (IME service sharing the user dir, migration, etc.).
+DASHER_API void dasher_reload_settings(dasher_ctx* ctx);
+
 // Reset every parameter to its built-in default value. Fires parameter-change
 // notifications so a live engine reconfigures itself (alphabet/colour/LM
 // reload, etc.). Does not delete the persisted settings files — frontends that

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -506,6 +506,24 @@ TEST(reload_settings) {
     ASSERT_EQ(dasher_get_speed_percent(ctx), 50); // kept, not reset
     ASSERT_EQ(param_changes, 0);                  // no spurious callbacks
 
+    // Wrong root: well-formed XML but not a settings file — same as
+    // malformed, keep current values and emit no callbacks.
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<not_settings>\n<long name=\"x\" "
+                  "value=\"1\"/>\n</not_settings>\n",
+                  f);
+            fclose(f);
+        }
+    }
+    param_changes = 0;
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 50); // kept, not reset
+    ASSERT_EQ(param_changes, 0);                  // no spurious callbacks
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -490,6 +490,22 @@ TEST(reload_settings) {
     ASSERT_EQ(default_speed, 50);
     ASSERT(param_changes > 0); // the removal triggered a notification
 
+    // Malformed file: external writer corrupts the XML — reload should
+    // keep current values (not reset to defaults) and emit no callbacks.
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("THIS IS NOT XML AT ALL <<<\n", f);
+            fclose(f);
+        }
+    }
+    param_changes = 0;
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 50); // kept, not reset
+    ASSERT_EQ(param_changes, 0);                  // no spurious callbacks
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -542,6 +542,43 @@ TEST(reload_settings) {
     ASSERT_EQ(dasher_get_speed_percent(ctx), 50); // kept, not reset
     ASSERT_EQ(param_changes, 0);                  // no spurious callbacks
 
+    // Nameless entry: a <long> with no name attribute is corruption —
+    // keep values, no callbacks. Set a non-default value first so a
+    // silent reset to default would be observable.
+    dasher_set_speed_percent(ctx, 120);
+    param_changes = 0;
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n<long value=\"560\"/>\n</settings>\n", f);
+            fclose(f);
+        }
+    }
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 120); // kept, not reset
+    ASSERT_EQ(param_changes, 0);                   // no spurious callbacks
+
+    // Wrong tag: a known parameter's storage name under the wrong element
+    // type — the entry would land in a map LoadPersistent never reads,
+    // resetting the setting to default. Corruption: keep values, no
+    // callbacks. (Speed's storage name is MaxBitRateTimes100.)
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n<bool name=\"MaxBitRateTimes100\" "
+                  "value=\"1\"/>\n</settings>\n",
+                  f);
+            fclose(f);
+        }
+    }
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 120); // kept, not reset
+    ASSERT_EQ(param_changes, 0);                   // no spurious callbacks
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -470,6 +470,26 @@ TEST(reload_settings) {
     dasher_reload_settings(ctx);
     ASSERT_EQ(param_changes, 0);
 
+    // Removed setting: external writer deletes the entry from the XML,
+    // reload should restore the declared default and notify.
+    {
+        // Write a settings file with the speed entry removed (just an
+        // empty settings element — simplest removal case)
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n</settings>\n", f);
+            fclose(f);
+        }
+    }
+    param_changes = 0;
+    dasher_reload_settings(ctx);
+    // Speed falls back to the manifest default (raw 80 = 50%)
+    const int default_speed = dasher_get_speed_percent(ctx);
+    ASSERT_EQ(default_speed, 50);
+    ASSERT(param_changes > 0); // the removal triggered a notification
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -418,6 +418,66 @@ TEST(reset_emits_buffer_clear_event) {
     dasher_destroy(ctx);
 }
 
+TEST(reload_settings) {
+    // dasher_reload_settings re-reads dasher_settings.xml and applies
+    // changes through the normal parameter path. This matters when the
+    // settings file changes externally (IME sharing the user dir, a
+    // migration moving the file) — the engine should pick up the change
+    // without being destroyed and recreated.
+    static int reload_test_counter = 0;
+    char user_dir[256];
+    snprintf(user_dir, sizeof(user_dir), "%s/dasher_reload_test_%d_%d", dasher_temp_dir(), dasher_getpid(),
+             reload_test_counter++);
+    dasher_mkdir(user_dir);
+
+    dasher_ctx* ctx = dasher_create(TEST_DATA_DIR, user_dir, nullptr);
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    // Set an initial speed and save
+    dasher_set_speed_percent(ctx, 200);
+    dasher_save_settings(ctx);
+    const int before = dasher_get_speed_percent(ctx);
+    ASSERT(before == 200);
+
+    // Simulate an external change: create a second engine that writes a
+    // different speed to the same settings file
+    {
+        dasher_ctx* writer = dasher_create(TEST_DATA_DIR, user_dir, nullptr);
+        ASSERT(writer != nullptr);
+        dasher_set_speed_percent(writer, 350);
+        dasher_save_settings(writer);
+        dasher_destroy(writer);
+    }
+
+    // The first engine still has its in-memory value
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 200);
+
+    // Track parameter-change notifications
+    static int param_changes = 0;
+    param_changes = 0;
+    dasher_set_parameter_callback(ctx, [](int key, void*) { param_changes++; }, nullptr);
+
+    // Reload — should pick up the external change
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 350);
+
+    // Parameter-change callback fired for the changed setting
+    ASSERT(param_changes > 0);
+
+    // Reload again with no file change — no spurious notifications
+    param_changes = 0;
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(param_changes, 0);
+
+    // Edit buffer survives the reload
+    // (not asserting content — just that the engine is still functional)
+    dasher_reset_output_text(ctx);
+    ASSERT(dasher_get_output_text(ctx) != nullptr);
+
+    dasher_destroy(ctx);
+}
+
 TEST(save_settings) {
     static int save_test_counter = 0;
     char shared_dir[256];

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -524,6 +524,24 @@ TEST(reload_settings) {
     ASSERT_EQ(dasher_get_speed_percent(ctx), 50); // kept, not reset
     ASSERT_EQ(param_changes, 0);                  // no spurious callbacks
 
+    // Invalid value: valid XML, valid root, but an unparseable value —
+    // treated as corruption, keep current values, no callbacks.
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n<long name=\"LP_MAX_BITRATE\" "
+                  "value=\"banana\"/>\n</settings>\n",
+                  f);
+            fclose(f);
+        }
+    }
+    param_changes = 0;
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 50); // kept, not reset
+    ASSERT_EQ(param_changes, 0);                  // no spurious callbacks
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -596,6 +596,23 @@ TEST(reload_settings) {
     ASSERT_EQ(dasher_get_speed_percent(ctx), 120); // kept, not reset
     ASSERT_EQ(param_changes, 0);                   // no spurious callbacks
 
+    // Overflow: an all-numeric value beyond LONG_MAX — strtol clamps to
+    // LONG_MAX and flags ERANGE; the clamped value must not be applied.
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n<long name=\"MaxBitRateTimes100\" "
+                  "value=\"99999999999999999999999999\"/>\n</settings>\n",
+                  f);
+            fclose(f);
+        }
+    }
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 120); // kept, not clamped-applied
+    ASSERT_EQ(param_changes, 0);                   // no spurious callbacks
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -579,12 +579,55 @@ TEST(reload_settings) {
     ASSERT_EQ(dasher_get_speed_percent(ctx), 120); // kept, not reset
     ASSERT_EQ(param_changes, 0);                   // no spurious callbacks
 
+    // Junk suffix: "12junk" must not validate — the 12 prefix would
+    // silently reach the live setter. Same for bool "truejunk".
+    {
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", user_dir);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n<long name=\"MaxBitRateTimes100\" "
+                  "value=\"12junk\"/>\n<bool name=\"AutoSpeedControl\" value=\"truejunk\"/>\n</settings>\n",
+                  f);
+            fclose(f);
+        }
+    }
+    dasher_reload_settings(ctx);
+    ASSERT_EQ(dasher_get_speed_percent(ctx), 120); // kept, not reset
+    ASSERT_EQ(param_changes, 0);                   // no spurious callbacks
+
     // Edit buffer survives the reload
     // (not asserting content — just that the engine is still functional)
     dasher_reset_output_text(ctx);
     ASSERT(dasher_get_output_text(ctx) != nullptr);
 
     dasher_destroy(ctx);
+
+    // Startup with a partially corrupt file: a corrupt entry followed by
+    // a valid one. The initial Load must pick up the valid entry —
+    // stopping the scan at the corrupt one made later settings load from
+    // defaults, giving a document-order-dependent configuration.
+    {
+        char dir2[256];
+        snprintf(dir2, sizeof(dir2), "%s/dasher_reload_test_partial_%d", dasher_temp_dir(), dasher_getpid());
+        dasher_mkdir(dir2);
+        char path[512];
+        snprintf(path, sizeof(path), "%s/dasher_settings.xml", dir2);
+        FILE* f = fopen(path, "w");
+        if (f) {
+            fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<settings>\n"
+                  "<long value=\"560\"/>\n"                                // corrupt: nameless
+                  "<long name=\"MaxBitRateTimes100\" value=\"12junk\"/>\n" // corrupt: junk suffix
+                  "<long name=\"MaxBitRateTimes100\" value=\"560\"/>\n"    // valid: speed 350%
+                  "</settings>\n",
+                  f);
+            fclose(f);
+        }
+        dasher_ctx* ctx2 = dasher_create(TEST_DATA_DIR, dir2, nullptr);
+        ASSERT(ctx2 != nullptr);
+        ASSERT_EQ(dasher_get_speed_percent(ctx2), 350); // valid entry loaded despite earlier corrupt ones
+        dasher_destroy(ctx2);
+    }
 }
 
 TEST(save_settings) {


### PR DESCRIPTION
For frontends where the settings file changes externally — Android's IME sharing a user directory with the main app (PR #29 follow-up), the future iOS keyboard extension, or a settings migration.

## The problem

Settings are read once at `dasher_create()` into an in-memory snapshot. If the file changes externally, the running engine never picks it up. The workaround (destroy and recreate) loses the edit buffer and re-registers all callbacks.

## The fix

```c
void dasher_reload_settings(dasher_ctx* ctx);
```

Re-reads `dasher_settings.xml` and applies **only changed parameters** through the normal `SetParameter` path — so parameter-change handlers fire (alphabet rebuild, colour change, input filter switch), the frontend callback notifies, and the edit buffer is preserved. Safe to call any time.

## Implementation notes

- `CSettingsStore::ReloadFromFile()`: snapshots current values, calls virtual `RefreshFromStore()`, then diffs and applies. Old values are temporarily restored before each `SetParameter` so the "nothing changed" early-return doesn't swallow the `OnParameterChanged` broadcast.
- `XmlSettingsStore::RefreshFromStore()`: re-parses the XML file (same path `Load()` uses), then `LoadPersistent` updates `parameters_` in place.
- The CAPI wrapper includes the standard error-boundary handling.

## Test

`reload_settings` in test_capi_extended: external-writer scenario — engine A sets speed 200, engine B writes 350 to the same file, reload picks up 350, parameter callback fires, second reload with no file change fires zero notifications, edit buffer survives.

Full suite: **39/39** green.

DCO signed.

















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a public settings-reload operation that re-reads the XML settings file, applies changed values through the normal notification path, and preserves the active engine session.
- Adds `dasher_reload_settings` to the public C API with exception-boundary handling.
- Adds snapshot-and-diff reload behavior to `CSettingsStore`.
- Makes XML refresh transactional so missing, malformed, or invalid files preserve current settings.
- Strengthens XML validation for roots, attributes, declared types, complete scalar parsing, and integer overflow.
- Adds regression coverage for external updates, removals, corrupt files, callbacks, and edit-buffer survival.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/DasherCore/XmlSettingsStore.cpp | Implements transactional XML refresh and strict validation; the previously reported malformed, missing, mistyped, and removed-setting paths are addressed. |
| src/DasherCore/SettingsStore.cpp | Adds snapshot-and-diff reload logic that routes changed values through typed setters and their normal notifications. |
| src/CAPI.cpp | Exposes settings reload through the existing C API exception boundary. |
| src/dasher.h | Declares and documents the new host-facing reload operation. |
| tests/test_capi_extended.cpp | Covers successful reloads, no-op reloads, removals, invalid files and values, callbacks, and retained engine state. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Host
    participant CAPI as C API
    participant Store as Settings Store
    participant XML as XML Store
    participant Runtime
    Host->>CAPI: dasher_reload_settings(ctx)
    CAPI->>Store: ReloadFromFile()
    Store->>Store: Snapshot live values
    Store->>XML: RefreshFromStore()
    XML->>XML: Parse and validate settings XML
    alt Parse succeeds
        XML->>Store: Repopulate persistent values
        Store->>Store: Diff old and new values
        Store->>Runtime: SetParameter(changed values)
        Runtime-->>Host: Parameter callbacks
    else Parse fails
        XML->>XML: Restore previous parsed maps
        Store->>Store: Observe no live changes
    end
```
</details>

<sub>Reviews (9): Last reviewed commit: ["style: align trailing comments in valid\_..."](https://github.com/dasher-project/dashercore/commit/4e22bd2c99f56ed99b9d65726ecfa40c3b6d7a26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57589974)</sub>

<!-- /greptile_comment -->