### PR TITLE
fix: informational warnings no longer pause Dasher — training-less alphabets writable (#70)

### DIFF
--- a/src/DasherCore/Messages.cpp
+++ b/src/DasherCore/Messages.cpp
@@ -25,3 +25,22 @@ void CMessageDisplay::FormatMessage(const char* format, ...) {
     FormatMessage(format, args);
     va_end(args);
 }
+
+void CMessageDisplay::FormatInfoMessage(const char* format, ...) {
+    if (format == nullptr) return;
+
+    std::string lineToPrint;
+
+    va_list args;
+    va_start(args, format);
+    va_list args_copy;
+    va_copy(args_copy, args);
+    const int length = vsnprintf(nullptr, 0, format, args_copy);
+    va_end(args_copy);
+
+    lineToPrint.resize(length);
+    vsnprintf(&lineToPrint[0], length + 1, format, args);
+    va_end(args);
+
+    Message(lineToPrint, false);
+}

--- a/src/DasherCore/Messages.h
+++ b/src/DasherCore/Messages.h
@@ -47,6 +47,15 @@ class CMessageDisplay {
     /// Utility method for common case of displaying a modal message with a format
     void FormatMessage(const char* format, va_list args);
     void FormatMessage(const char* format, ...);
+
+    /// Non-modal (asynchronous) variant: formatted, but does NOT interrupt
+    /// text entry. Informational diagnostics — e.g. the trainer's
+    /// "no training text" warnings — must use this: a modal message pauses
+    /// the input filter, and the unpause path is only reachable after the
+    /// model moves, so a modal warning at engine startup deadlocks Dasher
+    /// permanently (#70: 148 shipped alphabets declare training corpora we
+    /// don't ship, and every one of them froze on first input).
+    void FormatInfoMessage(const char* format, ...);
 };
 
 /// @}

--- a/src/DasherCore/NodeCreationManager.cpp
+++ b/src/DasherCore/NodeCreationManager.cpp
@@ -103,20 +103,23 @@ CNodeCreationManager::CNodeCreationManager(CSettingsStore* pSettingsStore, CDash
             /// TRANSLATORS: These 3 messages will be displayed when the user has just chosen a new alphabet. The %s
             /// parameter will be the name of the alphabet.
             if (pn.has_parsed_from_system_dir()) {
-                pInterface->FormatMessage("No user training text found - if you have written in \"%s\" before, this "
-                                          "means Dasher may not be learning from previous sessions",
-                                          pAlphInfo->GetID().c_str());
+                pInterface->FormatInfoMessage(
+                    "No user training text found - if you have written in \"%s\" before, this "
+                    "means Dasher may not be learning from previous sessions",
+                    pAlphInfo->GetID().c_str());
             } else {
-                pInterface->FormatMessage("No training text (user or system) found for \"%s\". Dasher will still work "
-                                          "but entry will be slower. We suggest downloading a training text file from "
-                                          "the Dasher website, or constructing your own.",
-                                          pAlphInfo->GetID().c_str());
+                pInterface->FormatInfoMessage(
+                    "No training text (user or system) found for \"%s\". Dasher will still work "
+                    "but entry will be slower. We suggest downloading a training text file from "
+                    "the Dasher website, or constructing your own.",
+                    pAlphInfo->GetID().c_str());
             }
         }
     } else {
-        pInterface->FormatMessage("\"%s\" does not specify training file. Dasher will work but entry will be slower. "
-                                  "Check you have the latest version of the alphabet definition.",
-                                  pAlphInfo->GetID().c_str());
+        pInterface->FormatInfoMessage(
+            "\"%s\" does not specify training file. Dasher will work but entry will be slower. "
+            "Check you have the latest version of the alphabet definition.",
+            pAlphInfo->GetID().c_str());
     }
 
     HandleParameterChange(LP_ORIENTATION);

--- a/tests/test_low_memory.cpp
+++ b/tests/test_low_memory.cpp
@@ -302,6 +302,63 @@ TEST(alphabet_index_scanner_edge_cases) {
     dasher_destroy(ctx);
 }
 
+TEST(alphabet_without_training_file_stays_writable) {
+    // Regression (#70): the trainer's "does not specify training file"
+    // warning used FormatMessage — the MODAL path, which pauses the input
+    // filter. The unpause path is only reachable after the model moves, so
+    // a modal warning at engine start deadlocked Dasher permanently: every
+    // alphabet without a (shipped) training corpus froze on first input —
+    // 148 shipped alphabets. Informational warnings now use the
+    // non-modal FormatInfoMessage; steering must keep working.
+    char dataDir[256], userDir[256];
+    static int counter = 0;
+    snprintf(dataDir, sizeof(dataDir), "%s/notrain_data_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
+    snprintf(userDir, sizeof(userDir), "%s/notrain_user_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
+    counter++;
+    dasher_mkdir(dataDir);
+    dasher_mkdir(userDir);
+
+    // Deliberately NO trainingFilename (and no corpus shipped for it).
+    // Paragraph + space nodes included: the model's offset accounting
+    // needs them (same shape as the shipped alphabets).
+    FILE* f = fopen((std::string(dataDir) + "/alphabet.notrain.xml").c_str(), "w");
+    ASSERT(f != nullptr);
+    fputs("<alphabet name='NoTrain Test' orientation='LR'><group name='Letters'>\n", f);
+    for (char c = 'a'; c <= 'z'; c++)
+        fprintf(f, "<node label='%c'><textCharAction /></node>\n", c);
+    fputs("</group>\n", f);
+    fputs("<group name='paragraphSpace'>\n", f);
+    fputs("<node label='&#182;' text='&#10;'><textCharAction /></node>\n", f);
+    fputs("<node label='&#9633;'><textCharAction unicode='32' /></node>\n", f);
+    fputs("</group></alphabet>\n", f);
+    fclose(f);
+
+    dasher_ctx* ctx = dasher_create(dataDir, userDir, nullptr);
+    ASSERT(ctx != nullptr);
+    // Select explicitly: without this the engine starts on the builtin
+    // Default alphabet (the only alternative in a one-alphabet data dir),
+    // which is a different test.
+    dasher_set_alphabet_id(ctx, "NoTrain Test");
+    dasher_set_screen_size(ctx, 800, 600);
+
+    // The canonical steering pattern (as low_memory_text_output): if the
+    // modal-pause deadlock returns, no frames move and output stays empty.
+    dasher_mouse_move(ctx, 700.0f, 300.0f);
+    dasher_mouse_down(ctx);
+    for (int i = 0; i < 100; i++) {
+        dasher_mouse_move(ctx, 700.0f, 280.0f);
+        run_frames(ctx, 1, 1000, 20);
+    }
+    dasher_mouse_up(ctx);
+
+    const char* text = dasher_get_output_text(ctx);
+    printf("  no-training output: '%s'\n", text ? text : "(null)");
+    ASSERT(text != nullptr);
+    ASSERT(strlen(text) > 0);
+
+    dasher_destroy(ctx);
+}
+
 TEST(low_memory_frame_commands) {
     // Frame should still produce valid draw commands in low-memory mode
     dasher_ctx* ctx = create_isolated_context();

--- a/tests/test_low_memory.cpp
+++ b/tests/test_low_memory.cpp
@@ -145,15 +145,13 @@ TEST(alphabet_index_duplicate_ids_prefer_maintained) {
     // the authoritative definition: maintained root file over the
     // autoConverted export over the oldAlphabets v5 original. Both orders
     // are created here explicitly so the test cannot depend on readdir luck.
-    char dataDir[256], userDir[256];
-    static int counter = 0;
-    snprintf(dataDir, sizeof(dataDir), "%s/dup_data_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
-    snprintf(userDir, sizeof(userDir), "%s/dup_user_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
-    counter++;
+    // ScopedTempDir: stale-dir removal + RAII cleanup (see the scanner
+    // edge-case test for the flakiness this prevents).
+    ScopedTempDir dataDir, userDir;
     char sub[512];
-    snprintf(sub, sizeof(sub), "%s/oldAlphabets", dataDir);
-    dasher_mkdir(dataDir);
-    dasher_mkdir(sub);
+    snprintf(sub, sizeof(sub), "%s/oldAlphabets", dataDir.c_str());
+    std::error_code ec;
+    std::filesystem::create_directories(sub, ec);
 
     // Maintained definition: 30 letters — 31 symbols, deliberately unlike
     // the builtin Default alphabet (26 letters / 27 symbols) so the count
@@ -198,15 +196,20 @@ TEST(alphabet_index_duplicate_ids_prefer_maintained) {
     // the ancestor name must not collapse every file to the legacy tier
     // (the old substring-based tier check did, making the winner traversal
     // luck again).
+    // Stale-state removal first (review): a reused PID with leftovers from
+    // a previous run would resurrect old settings/files. ScopedTempDir
+    // can't be used here — the data dir must live INSIDE a folder literally
+    // named oldAlphabets — so clear the whole nested subtree manually.
     char nested[512], nestedData[512], nestedUser[512], nestedOld[512];
     snprintf(nested, sizeof(nested), "%s/oldAlphabets", dasher_temp_dir());
     snprintf(nestedData, sizeof(nestedData), "%s/nested_data_%d", nested, dasher_getpid());
     snprintf(nestedUser, sizeof(nestedUser), "%s/nested_user_%d", nested, dasher_getpid());
     snprintf(nestedOld, sizeof(nestedOld), "%s/oldAlphabets", nestedData);
-    dasher_mkdir(nested);
-    dasher_mkdir(nestedData);
-    dasher_mkdir(nestedUser);
-    dasher_mkdir(nestedOld);
+    std::filesystem::remove_all(nestedData, ec);
+    std::filesystem::remove_all(nestedUser, ec);
+    std::filesystem::create_directories(nested, ec);
+    std::filesystem::create_directories(nestedOld, ec);
+    std::filesystem::create_directories(nestedUser, ec);
 
     f = fopen((std::string(nestedData) + "/alphabet.dup.xml").c_str(), "w");
     ASSERT(f != nullptr);
@@ -247,14 +250,12 @@ TEST(alphabet_index_scanner_edge_cases) {
     // a 2048-byte prefix. The indexer now uses pugixml itself. All three
     // edge cases live in one file: single quotes, numeric character
     // references, and a prolog pushing the root past 2048 bytes.
-    char dataDir[256], userDir[256], path[512];
-    static int counter = 0;
-    snprintf(dataDir, sizeof(dataDir), "%s/idx_edge_data_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
-    snprintf(userDir, sizeof(userDir), "%s/idx_edge_user_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
-    counter++;
-    dasher_mkdir(dataDir);
-    dasher_mkdir(userDir);
-    snprintf(path, sizeof(path), "%s/alphabet.turkmen.entity.xml", dataDir);
+    // ScopedTempDir: stale-dir removal + RAII cleanup (a reused PID with a
+    // leftover dasher_settings.xml made tests non-deterministic — the same
+    // failure mode create_isolated_context() documents).
+    ScopedTempDir dataDir, userDir;
+    char path[512];
+    snprintf(path, sizeof(path), "%s/alphabet.turkmen.entity.xml", dataDir.c_str());
 
     FILE* f = fopen(path, "w");
     ASSERT(f != nullptr);
@@ -310,13 +311,9 @@ TEST(alphabet_without_training_file_stays_writable) {
     // alphabet without a (shipped) training corpus froze on first input —
     // 148 shipped alphabets. Informational warnings now use the
     // non-modal FormatInfoMessage; steering must keep working.
-    char dataDir[256], userDir[256];
-    static int counter = 0;
-    snprintf(dataDir, sizeof(dataDir), "%s/notrain_data_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
-    snprintf(userDir, sizeof(userDir), "%s/notrain_user_%d_%d", dasher_temp_dir(), dasher_getpid(), counter);
-    counter++;
-    dasher_mkdir(dataDir);
-    dasher_mkdir(userDir);
+    // ScopedTempDir: stale-dir removal + RAII cleanup (same rationale as
+    // the other tests in this file).
+    ScopedTempDir dataDir, userDir;
 
     // Deliberately NO trainingFilename (and no corpus shipped for it).
     // Paragraph + space nodes included: the model's offset accounting


### PR DESCRIPTION
Closes the writable half of #70.

## Root cause

`FormatMessage` hardwired the **modal** path: `Message(text, /*bInterrupt=*/true)` queues a modal message **and pauses the input filter**. The unpause path (`onUnpause`) is only reachable after the model moves — which cannot happen while paused. **Any modal message at engine startup deadlocks Dasher permanently.**

The trainer fires exactly such warnings at startup for every alphabet whose training corpus is absent — **148 shipped alphabets** declare training files we don't ship, and dozens more (Amharic; legacy no-`trainingFilename` files like Adangbe and Azeri) never declared one. Every one rendered fine but **froze on first input** — zero output wherever you steered.

## Fix

- New `CMessageDisplay::FormatInfoMessage` (formatted, non-modal — does not interrupt text entry)
- The three trainer warnings now use it; genuinely modal alerts keep `FormatMessage`

## #70 decomposition (full evidence in the issue)

| Case | Verdict |
|---|---|
| RTL alphabets "no output" | **Never a bug** — the crosshair mirrors to the left edge; steering from the left works (Hebrew 134 B, Arabic 100 B in probes). The tofu glyphs (fixed in Dasher-GTK#71) made it *look* unwritable. |
| Missing-corpus alphabets | **This PR** — Amharic 0→81 B, Adangbe 0→44 B, engine-level probes with the log callback attached |
| Modal-pause deadlock itself | Still latent for genuinely modal messages (`onUnpause` unreachable while paused) — follow-up noted in #70 |

## Tests

- Regression: synthetic alphabet without `trainingFilename`, canonical steering pattern, output must be non-empty (fails on main, passes here)
- Suite 39/39

DCO signed.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a formatted non-modal message path and routes missing-training-data warnings through it so startup diagnostics no longer pause text entry.
- Adds `FormatInfoMessage` alongside the existing modal formatter.
- Converts the three trainer warnings to informational messages.
- Adds a writable-alphabet regression test and strengthens temporary-directory isolation in related tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/DasherCore/Messages.cpp | Implements formatted informational messages and sends them through the existing non-interrupting message path. |
| src/DasherCore/Messages.h | Declares and documents the new non-modal formatting API. |
| src/DasherCore/NodeCreationManager.cpp | Routes all three missing-training-data diagnostics through the non-modal API. |
| tests/test_low_memory.cpp | Adds the missing-training-file writability regression and replaces affected temporary paths with stale-state-clearing scoped directories. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Trainer
    participant Display as CMessageDisplay
    participant Host
    participant Input as Input filter
    Trainer->>Display: FormatInfoMessage(warning)
    Display->>Host: Message(text, false)
    Note over Display,Input: Informational warning does not pause input
    Host->>Input: Pointer input and frames
    Input-->>Host: Text output
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tests): scoped temp dirs in the lazy..."](https://github.com/dasher-project/dashercore/commit/b4b93e46dc02b8e874b68e7bf70a4f66e2739f22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58125194)</sub>

<!-- /greptile_comment -->