### PR TITLE
fix: UTF-8 encode the × in LP_UNIFORM's description

### DIFF
--- a/src/DasherCore/Parameters.cpp
+++ b/src/DasherCore/Parameters.cpp
@@ -227,7 +227,7 @@ const std::unordered_map<Parameter, const Parameter_Value> parameter_defaults = 
                                     "Control",
                                     "Input"}},
     {LP_UNIFORM, Parameter_Value{"UniformTimes1000", PARAM_LONG, Persistence::PERSISTENT, 50l,
-                                 "Uniform probability weight (×1000). Higher values make less-probable symbols larger.",
+                                 "Uniform probability weight (Ã—1000). Higher values make less-probable symbols larger.",
                                  "Uniform Probability", Settings::UIControlType::Slider, 0, 1000, 1, 10, true,
                                  "LP_UNIFORM", "Advanced", "Input"}},
     {LP_MOUSEPOSDIST,


### PR DESCRIPTION
The description contained `×` (U+00D7) as a single Latin-1 byte (`0xD7`) instead of UTF-8 (`0xC3 0x97`) — a mojibake "fix" that traded wrong bytes for broken encoding.

**Impact**: JNI's `NewStringUTF` validates Modified UTF-8 and **aborts the JVM** the moment the string crosses the boundary — the Android app crashed on opening Settings (which calls `nativeGetParameterInfo` for every parameter).

One-byte fix in `Parameters.cpp`. Verified valid UTF-8.

DCO signed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the LP_UNIFORM parameter description so its multiplication sign is represented as valid UTF-8, preventing invalid text from crossing host string boundaries.
- Replaces the malformed character in the generated C++ parameter metadata with U+00D7.
- Remains aligned with the canonical manifest and English localization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The corrected parameter description is valid UTF-8 and remains consistent with its manifest source and English localization.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/DasherCore/Parameters.cpp | The corrected UTF-8 multiplication sign matches the canonical manifest and localized English description; no issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: UTF-8 encode the multiplication sig..."](https://github.com/dasher-project/dashercore/commit/a253822b75159608f83d4830a581a3b60d0b507a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58261650)</sub>

**Context used:**

- Knowledge Base — [Configuration and content](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/configuration-and-content.md)
- Knowledge Base — [Settings and parameter management](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/settings-and-parameter-management.md)

<!-- /greptile_comment -->