### PR TITLE
fix: ScanFiles skips bad entries; failed Realize latches engineError

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -949,6 +949,20 @@ DASHER_API void dasher_set_screen_size(dasher_ctx* ctx, int width, int height) {
     }
 
     if (!ctx->realized) {
+        // A previous failed Realize left the interface incrementally mutated
+        // (CreateModules registers onto the existing module manager; other
+        // components are rebuilt in place), so retrying Realize() on it could
+        // retain or duplicate state from the failed attempt. Recreate the
+        // interface first: the settings store and all ctx-level state (screen,
+        // callbacks, pending alphabet) survive; the fresh Realize rebuilds
+        // every component. PointerInput is owned by the old interface's module
+        // manager, so null it before the delete — CreateModules re-establishes.
+        if (ctx->engineError) {
+            ctx->input = nullptr;
+            delete ctx->intf;
+            ctx->intf = new dasher_ctx::Interface(ctx->settings.get(), ctx);
+            ctx->intf->ChangeScreen(ctx->screen.get());
+        }
         // On a fresh install (no settings file existed at create time),
         // apply the canonical default BEFORE Realize(). We use
         // SetStringParameter with the parameter-table default — NOT

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -986,6 +986,14 @@ DASHER_API void dasher_set_screen_size(dasher_ctx* ctx, int width, int height) {
             return;
         }
         ctx->realized = true;
+        // A successful (re)realize rebuilt the interface from scratch, so an
+        // engineError latched by a previous failed Realize is obsolete. That
+        // failed-Realize path is the only one that latches while !realized
+        // (mid-frame throws leave realized set and never re-enter this
+        // block), so clearing here cannot mask a live fault. Without this,
+        // one failed realize + a successful retry left the engine permanently
+        // no-op'ing (review P1 on #77).
+        ctx->engineError = false;
 
         if (!ctx->pendingAlphabet.empty()) {
             std::string pending = ctx->pendingAlphabet;

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -488,6 +488,9 @@ struct dasher_ctx {
     std::deque<std::chrono::steady_clock::time_point> rateTimestamps;
     std::string tlString;
     bool realized = false;
+    // Host's low-memory request, retained on the ctx so the transactional
+    // realize retry can reapply it to a recreated interface (review P1 #77).
+    bool lowMemory = false;
     bool mouseDown = false;
     // Latched true when a C++ exception was caught at the C-API boundary of a
     // per-frame entry point (frame/mouse/key). Once set, those entry points
@@ -931,7 +934,8 @@ DASHER_API void dasher_destroy(dasher_ctx* ctx) {
 
 DASHER_API void dasher_set_low_memory_mode(dasher_ctx* ctx, int enabled) {
     if (!ctx || !ctx->intf) return;
-    ctx->intf->SetLowMemoryMode(enabled != 0);
+    ctx->lowMemory = (enabled != 0);
+    ctx->intf->SetLowMemoryMode(ctx->lowMemory);
 }
 
 DASHER_API void dasher_set_screen_size(dasher_ctx* ctx, int width, int height) {
@@ -961,6 +965,9 @@ DASHER_API void dasher_set_screen_size(dasher_ctx* ctx, int width, int height) {
             ctx->input = nullptr;
             delete ctx->intf;
             ctx->intf = new dasher_ctx::Interface(ctx->settings.get(), ctx);
+            // The host's low-memory request was applied to the old interface;
+            // reapply so the retry honours the memory constraint (review P1).
+            ctx->intf->SetLowMemoryMode(ctx->lowMemory);
             ctx->intf->ChangeScreen(ctx->screen.get());
         }
         // On a fresh install (no settings file existed at create time),

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -973,8 +973,17 @@ DASHER_API void dasher_set_screen_size(dasher_ctx* ctx, int width, int height) {
             ctx->intf->Realize(nowMs());
         } catch (const std::exception& e) {
             log_boundary_error(ctx, "dasher_set_screen_size: Realize failed", e.what());
+            // A half-completed Realize leaves the interface in an
+            // indeterminate state (e.g. a null node model). Setting realized
+            // anyway made the next dasher_frame assert on that null model.
+            // Latch the RFC 0009 error state instead: frame()/input no-op and
+            // dasher_has_engine_error() reports it; the frontend can surface it.
+            ctx->engineError = true;
+            return;
         } catch (...) {
             log_boundary_error(ctx, "dasher_set_screen_size: Realize failed", "unknown exception");
+            ctx->engineError = true;
+            return;
         }
         ctx->realized = true;
 

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -69,11 +69,21 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
     }
 
     for (const std::filesystem::path& current_path : search_paths) {
-        if (!std::filesystem::exists(current_path)) continue;
-        // Use recursive_directory_iterator to search subdirectories
-        for (const auto& entry : std::filesystem::recursive_directory_iterator(current_path)) {
-            if (entry.is_regular_file() && std::regex_search(entry.path().filename().string(), pattern)) {
-                parser->ParseFile(entry.path().string(), IsFileWriteable(entry.path()));
+        std::error_code exists_ec;
+        if (!std::filesystem::exists(current_path, exists_ec) || exists_ec) continue;
+        // Use recursive_directory_iterator to search subdirectories. One bad
+        // entry (dangling symlink, permission race, bundle metadata) must not
+        // abort the whole scan: entry.is_regular_file()/iteration use the
+        // error_code overloads and skip on failure. The throwing overloads
+        // here left Realize() half-complete with realized=true and a null
+        // model (watch spike crash, 2026-08-31).
+        std::error_code iter_ec;
+        for (std::filesystem::recursive_directory_iterator it(current_path, iter_ec), end;
+             it != end && !iter_ec; it.increment(iter_ec)) {
+            std::error_code entry_ec;
+            if (it->is_regular_file(entry_ec) && !entry_ec &&
+                std::regex_search(it->path().filename().string(), pattern)) {
+                parser->ParseFile(it->path().string(), IsFileWriteable(it->path()));
             }
         }
     }

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -3,6 +3,7 @@
 
 #include <regex>
 #include <filesystem>
+#include <unordered_set>
 #include <fstream>
 
 namespace Dasher {
@@ -90,22 +91,29 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
             // successfully read entry; a second failure abandons the
             // directory. Siblings and later directories are unaffected.
             bool restarted = false;
-            std::string lastName;
             std::error_code it_ec;
             std::filesystem::directory_iterator it(dir, it_ec);
             const std::filesystem::directory_iterator end;
+            // Identity-based visited set: std::filesystem does not guarantee
+            // iteration order, so the recovery rescan cannot skip "past the
+            // last name" — a different enumeration order would silently skip
+            // unseen entries (review P1 on #77). The set also makes the rescan
+            // idempotent (no double ParseFile).
+            std::unordered_set<std::string> visited;
             while (!it_ec && it != end) {
-                std::error_code ent_ec;
-                const std::filesystem::path p = it->path();
-                lastName = p.filename().string();
-                if (it->is_symlink(ent_ec) || ent_ec) {
-                    // skip; fall through to the increment below
-                } else if (it->is_directory(ent_ec) && !ent_ec) {
-                    pending.push_back(p);
-                } else {
-                    ent_ec.clear();
-                    if (it->is_regular_file(ent_ec) && !ent_ec && std::regex_search(p.filename().string(), pattern)) {
-                        parser->ParseFile(p.string(), IsFileWriteable(p));
+                const std::string name = it->path().filename().string();
+                if (visited.insert(name).second) {
+                    std::error_code ent_ec;
+                    const std::filesystem::path p = it->path();
+                    if (it->is_symlink(ent_ec) || ent_ec) {
+                        // skip symlinks / unreadable entries
+                    } else if (it->is_directory(ent_ec) && !ent_ec) {
+                        pending.push_back(p);
+                    } else {
+                        ent_ec.clear();
+                        if (it->is_regular_file(ent_ec) && !ent_ec && std::regex_search(name, pattern)) {
+                            parser->ParseFile(p.string(), IsFileWriteable(p));
+                        }
                     }
                 }
                 it.increment(it_ec);
@@ -116,10 +124,7 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
                     std::error_code re_ec;
                     std::filesystem::directory_iterator re(dir, re_ec);
                     if (re_ec) break;
-                    while (re != end && !re_ec && re->path().filename().string() <= lastName)
-                        re.increment(re_ec);
-                    if (re_ec) break;
-                    it = re;
+                    it = re; // full rescan; the visited set skips handled entries
                 }
             }
         }

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -83,11 +83,33 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
         while (!pending.empty()) {
             const std::filesystem::path dir = pending.back();
             pending.pop_back();
+            // One restart on a transient iteration error: a failed increment
+            // invalidates the iterator, so the directory is re-opened and
+            // scanned past the last successfully read entry (directory order
+            // is a stable per-open sequence on the platforms we ship). The
+            // restart is bounded — a persistently failing directory is
+            // abandoned after it, but its siblings and later directories are
+            // not affected (review P1 on #77).
+            bool restarted = false;
+            std::string lastName;
             std::error_code it_ec;
             for (std::filesystem::directory_iterator it(dir, it_ec), end; !it_ec && it != end;
                  it.increment(it_ec)) {
+                if (it_ec) {
+                    if (restarted) break;
+                    restarted = true;
+                    it_ec.clear();
+                    std::error_code re_ec;
+                    std::filesystem::directory_iterator re(dir, re_ec);
+                    if (re_ec) break;
+                    it = re;
+                    while (it != end && it->path().filename().string() <= lastName) it.increment(re_ec);
+                    if (re_ec) break;
+                    continue;
+                }
                 std::error_code ent_ec;
                 const std::filesystem::path p = it->path();
+                lastName = p.filename().string();
                 if (it->is_symlink(ent_ec) || ent_ec) continue;
                 if (it->is_directory(ent_ec) && !ent_ec) {
                     pending.push_back(p);

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -59,31 +59,45 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
     // Note: pattern is interpreted as regex, so "alphabet.*.xml" matches "alphabet.English.xml"
     const std::regex pattern = std::regex(strPattern);
 
-    // Search in the specified data directory (or current directory if not set)
-    // Uses recursive_directory_iterator to find files in subdirectories
+    // Search ONLY in the specified data directory. The old fallback to
+    // current_path() turned an empty/missing data dir (frontend passed a bad
+    // bundle path) into an unbounded scan of the user's home directory —
+    // minutes of regex per file while the caller held its engine lock
+    // (watch spike hang, 2026-08-31). No data dir means nothing to scan.
     std::vector<std::filesystem::path> search_paths;
     if (!s_dataDirectory.empty()) {
         search_paths.push_back(std::filesystem::path(s_dataDirectory));
-    } else {
-        search_paths.push_back(std::filesystem::current_path());
     }
 
     for (const std::filesystem::path& current_path : search_paths) {
         std::error_code exists_ec;
         if (!std::filesystem::exists(current_path, exists_ec) || exists_ec) continue;
-        // Use recursive_directory_iterator to search subdirectories. One bad
-        // entry (dangling symlink, permission race, bundle metadata) must not
-        // abort the whole scan: entry.is_regular_file()/iteration use the
-        // error_code overloads and skip on failure. The throwing overloads
-        // here left Realize() half-complete with realized=true and a null
-        // model (watch spike crash, 2026-08-31).
-        std::error_code iter_ec;
-        for (std::filesystem::recursive_directory_iterator it(current_path, iter_ec), end;
-             it != end && !iter_ec; it.increment(iter_ec)) {
-            std::error_code entry_ec;
-            if (it->is_regular_file(entry_ec) && !entry_ec &&
-                std::regex_search(it->path().filename().string(), pattern)) {
-                parser->ParseFile(it->path().string(), IsFileWriteable(it->path()));
+        // Iterative walk that isolates failures PER DIRECTORY: one
+        // inaccessible or transiently failing subtree skips just that
+        // subtree; sibling directories still scan (review P1 on #77 — a
+        // mid-iteration error previously ended the whole search root, and the
+        // throwing overloads before that aborted Realize entirely). Symlinks
+        // are never followed — matches recursive_directory_iterator's default
+        // and avoids cycles.
+        std::vector<std::filesystem::path> pending{current_path};
+        while (!pending.empty()) {
+            const std::filesystem::path dir = pending.back();
+            pending.pop_back();
+            std::error_code it_ec;
+            for (std::filesystem::directory_iterator it(dir, it_ec), end; !it_ec && it != end;
+                 it.increment(it_ec)) {
+                std::error_code ent_ec;
+                const std::filesystem::path p = it->path();
+                if (it->is_symlink(ent_ec) || ent_ec) continue;
+                if (it->is_directory(ent_ec) && !ent_ec) {
+                    pending.push_back(p);
+                    continue;
+                }
+                ent_ec.clear();
+                if (it->is_regular_file(ent_ec) && !ent_ec &&
+                    std::regex_search(p.filename().string(), pattern)) {
+                    parser->ParseFile(p.string(), IsFileWriteable(p));
+                }
             }
         }
     }

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -83,18 +83,32 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
         while (!pending.empty()) {
             const std::filesystem::path dir = pending.back();
             pending.pop_back();
-            // One restart on a transient iteration error: a failed increment
-            // invalidates the iterator, so the directory is re-opened and
-            // scanned past the last successfully read entry (directory order
-            // is a stable per-open sequence on the platforms we ship). The
-            // restart is bounded — a persistently failing directory is
-            // abandoned after it, but its siblings and later directories are
-            // not affected (review P1 on #77).
+            // Increment (and its recovery) live INSIDE the loop body: with
+            // increment in the for-header, a set error_code failed the loop
+            // condition before any recovery could run (review P1 on #77).
+            // Recovery re-opens the directory once and skips past the last
+            // successfully read entry; a second failure abandons the
+            // directory. Siblings and later directories are unaffected.
             bool restarted = false;
             std::string lastName;
             std::error_code it_ec;
-            for (std::filesystem::directory_iterator it(dir, it_ec), end; !it_ec && it != end;
-                 it.increment(it_ec)) {
+            std::filesystem::directory_iterator it(dir, it_ec);
+            const std::filesystem::directory_iterator end;
+            while (!it_ec && it != end) {
+                std::error_code ent_ec;
+                const std::filesystem::path p = it->path();
+                lastName = p.filename().string();
+                if (it->is_symlink(ent_ec) || ent_ec) {
+                    // skip; fall through to the increment below
+                } else if (it->is_directory(ent_ec) && !ent_ec) {
+                    pending.push_back(p);
+                } else {
+                    ent_ec.clear();
+                    if (it->is_regular_file(ent_ec) && !ent_ec && std::regex_search(p.filename().string(), pattern)) {
+                        parser->ParseFile(p.string(), IsFileWriteable(p));
+                    }
+                }
+                it.increment(it_ec);
                 if (it_ec) {
                     if (restarted) break;
                     restarted = true;
@@ -102,23 +116,10 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
                     std::error_code re_ec;
                     std::filesystem::directory_iterator re(dir, re_ec);
                     if (re_ec) break;
-                    it = re;
-                    while (it != end && it->path().filename().string() <= lastName) it.increment(re_ec);
+                    while (re != end && !re_ec && re->path().filename().string() <= lastName)
+                        re.increment(re_ec);
                     if (re_ec) break;
-                    continue;
-                }
-                std::error_code ent_ec;
-                const std::filesystem::path p = it->path();
-                lastName = p.filename().string();
-                if (it->is_symlink(ent_ec) || ent_ec) continue;
-                if (it->is_directory(ent_ec) && !ent_ec) {
-                    pending.push_back(p);
-                    continue;
-                }
-                ent_ec.clear();
-                if (it->is_regular_file(ent_ec) && !ent_ec &&
-                    std::regex_search(p.filename().string(), pattern)) {
-                    parser->ParseFile(p.string(), IsFileWriteable(p));
+                    it = re;
                 }
             }
         }


### PR DESCRIPTION
Found while driving the DasherWatch spike (Dasher-Apple spike/apple-watch), reproduced under lldb and with a host-side harness.

## Bug 1 - ScanFiles could abort the alphabet scan
`FileUtils::ScanFiles` used the **throwing** `directory_entry::is_regular_file()` inside the recursive scan. One bad entry (dangling symlink, permission race, bundle metadata) threw a `std::filesystem::filesystem_error` out of `CAlphIO::ScanNameIndex` -> `Realize()` - killing engine startup. Now uses the `error_code` overloads: failing entries are skipped, iteration failures end that search path cleanly.

## Bug 2 - a failed Realize left a live-looking engine
`dasher_set_screen_size` wrapped `Realize()` in a catch that logged and **set realized = true anyway**. The next `dasher_frame` then ran `NewFrame -> Redraw -> RenderToView` against the half-built interface and died on `DASHER_ASSERT(m_Root != NULL)` (watchOS simulator, deterministic). Now a failed Realize **latches the RFC 0009 engineError state** (frame/input no-op, `dasher_has_engine_error()` reports it, frontends surface it) and leaves realized = false so a subsequent resize retries the realize instead of asserting.

## Verification
- watchOS simulator: crash-on-launch (assert) -> 3 stable processes, canvas rendering, no new crash reports
- Host harness (macOS static libs, trimmed watch data bundle, German alphabet restore): previously-reproducing paths survive











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes resource scanning resilient to individual filesystem failures and makes failed realization retry against a fresh interface while preserving low-memory configuration.
- Replaces recursive filesystem traversal with an error-code-based, per-directory scan and bounded order-independent recovery.
- Latches realization failures as engine errors so frame and input calls remain safe.
- Recreates the interface transactionally on retry and reapplies the screen and low-memory request.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/CAPI.cpp | Failed realization now latches the engine fault, while retry rebuilds the interface and restores low-memory and screen configuration before clearing the fault. |
| src/DasherCore/FileUtils.cpp | Resource discovery now isolates entry and directory errors and performs one order-independent rescan without parsing already visited entries twice. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: retry reapplies low-memory mode to ..."](https://github.com/dasher-project/dashercore/commit/ca771baf0ec52e4cd116e53b7d4ee3658aeef1c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58544395)</sub>

<!-- /greptile_comment -->