### PR TITLE
test: direct-mode shadow-buffer invariant over forward/reverse/forward

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ if(BUILD_CAPI)
 
         dasher_add_test(dasher_capi_tests test_capi.cpp)
         dasher_add_test(dasher_interaction_tests test_interaction.cpp)
+        dasher_add_test(dasher_direct_mode_shadow_tests test_direct_mode_shadow.cpp)
         dasher_add_test(dasher_low_memory_tests test_low_memory.cpp)
         dasher_add_test(dasher_extended_tests test_capi_extended.cpp)
 dasher_add_test(dasher_text_metrics_tests test_text_metrics.cpp)

--- a/tests/test_direct_mode_shadow.cpp
+++ b/tests/test_direct_mode_shadow.cpp
@@ -24,7 +24,8 @@ struct ShadowBuffer {
                 if ((*p & 0xC0) != 0x80) cps++;
             for (int i = 0; i < cps && !buf.empty(); i++) {
                 buf.pop_back();
-                while (!buf.empty() && ((unsigned char)buf.back() & 0xC0) == 0x80) buf.pop_back();
+                while (!buf.empty() && ((unsigned char)buf.back() & 0xC0) == 0x80)
+                    buf.pop_back();
             }
         } else if (type == 2) {
             buf.clear();
@@ -45,8 +46,7 @@ bool check(dasher_ctx* ctx, const char* stage, int& divergences) {
     std::string eng = engine ? engine : "";
     if (eng != g_shadow.buf) {
         divergences++;
-        printf("  DIVERGENCE at %s:\n    engine: '%s'\n    shadow: '%s'\n", stage, eng.c_str(),
-               g_shadow.buf.c_str());
+        printf("  DIVERGENCE at %s:\n    engine: '%s'\n    shadow: '%s'\n", stage, eng.c_str(), g_shadow.buf.c_str());
         const size_t n = g_shadow.log.size();
         for (size_t i = n >= 16 ? n - 16 : 0; i < n; i++)
             printf("    event '%s'\n", g_shadow.log[i].c_str());
@@ -65,14 +65,11 @@ TEST(direct_mode_sweep_reverse_lengths) {
     const int reverseFrames[] = {30, 40, 50, 60, 80, 100, 120, 150, 200, 250};
     for (int rev : reverseFrames) {
         for (int pause = 0; pause <= 1; pause++) {
-            dasher_ctx* ctx = create_isolated_context();
-            ASSERT(ctx != nullptr);
+            ScopedContext sc;
+            dasher_ctx* ctx = sc;
             g_shadow.buf.clear();
             g_shadow.log.clear();
-            dasher_set_output_callback(
-                ctx,
-                [](int e, const char* t, void*) { g_shadow.onEvent(e, t); },
-                nullptr);
+            dasher_set_output_callback(ctx, [](int e, const char* t, void*) { g_shadow.onEvent(e, t); }, nullptr);
             dasher_set_speed_percent(ctx, 300);
             dasher_set_screen_size(ctx, 800, 600);
 
@@ -86,19 +83,13 @@ TEST(direct_mode_sweep_reverse_lengths) {
             steer(ctx, 700.0f, 300.0f, 120, t);
             steer(ctx, 700.0f, 288.0f, 180, t);
             snprintf(stage, sizeof(stage), "rev=%d pause=%d after-forward1", rev, pause);
-            if (!check(ctx, stage, failures)) {
-                dasher_destroy(ctx);
-                continue;
-            }
+            if (!check(ctx, stage, failures)) continue;
 
             if (pause) dasher_mouse_up(ctx);
             steer(ctx, 60.0f, 300.0f, rev, t);
             if (pause) dasher_mouse_down(ctx);
             snprintf(stage, sizeof(stage), "rev=%d pause=%d after-reverse", rev, pause);
-            if (!check(ctx, stage, failures)) {
-                dasher_destroy(ctx);
-                continue;
-            }
+            if (!check(ctx, stage, failures)) continue;
 
             steer(ctx, 700.0f, 285.0f, 160, t);
             steer(ctx, 700.0f, 300.0f, 120, t);
@@ -106,7 +97,6 @@ TEST(direct_mode_sweep_reverse_lengths) {
             check(ctx, stage, failures);
 
             dasher_mouse_up(ctx);
-            dasher_destroy(ctx);
         }
     }
 

--- a/tests/test_direct_mode_shadow.cpp
+++ b/tests/test_direct_mode_shadow.cpp
@@ -1,0 +1,115 @@
+// Sweep: shallow reversals of varying length (delete ~1 word) followed by
+// forward zooms — hunting for the "messes up the previous word" divergence.
+#include "test_common.h"
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct ShadowBuffer {
+    std::string buf;
+    std::vector<std::string> log;
+
+    void onEvent(int type, const char* text) {
+        char header[64];
+        snprintf(header, sizeof(header), "%d:", type);
+        log.push_back(std::string(header) + (text ? text : ""));
+        if (type == 0 && text) {
+            buf += text;
+        } else if (type == 1 && text) {
+            int cps = 0;
+            for (const unsigned char* p = (const unsigned char*)text; *p; ++p)
+                if ((*p & 0xC0) != 0x80) cps++;
+            for (int i = 0; i < cps && !buf.empty(); i++) {
+                buf.pop_back();
+                while (!buf.empty() && ((unsigned char)buf.back() & 0xC0) == 0x80) buf.pop_back();
+            }
+        } else if (type == 2) {
+            buf.clear();
+        }
+    }
+};
+
+ShadowBuffer g_shadow;
+
+void steer(dasher_ctx* ctx, float x, float y, int frames, unsigned long& t) {
+    dasher_mouse_move(ctx, x, y);
+    run_frames(ctx, frames, t);
+    t += frames * 16;
+}
+
+bool check(dasher_ctx* ctx, const char* stage, int& divergences) {
+    const char* engine = dasher_get_output_text(ctx);
+    std::string eng = engine ? engine : "";
+    if (eng != g_shadow.buf) {
+        divergences++;
+        printf("  DIVERGENCE at %s:\n    engine: '%s'\n    shadow: '%s'\n", stage, eng.c_str(),
+               g_shadow.buf.c_str());
+        const size_t n = g_shadow.log.size();
+        for (size_t i = n >= 16 ? n - 16 : 0; i < n; i++)
+            printf("    event '%s'\n", g_shadow.log[i].c_str());
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+TEST(direct_mode_sweep_reverse_lengths) {
+    int scenarios = 0, failures = 0;
+
+    // Vary the reverse duration: shallow (a word) through deep, with and
+    // without mouse-up pauses between the phases.
+    const int reverseFrames[] = {30, 40, 50, 60, 80, 100, 120, 150, 200, 250};
+    for (int rev : reverseFrames) {
+        for (int pause = 0; pause <= 1; pause++) {
+            dasher_ctx* ctx = create_isolated_context();
+            ASSERT(ctx != nullptr);
+            g_shadow.buf.clear();
+            g_shadow.log.clear();
+            dasher_set_output_callback(
+                ctx,
+                [](int e, const char* t, void*) { g_shadow.onEvent(e, t); },
+                nullptr);
+            dasher_set_speed_percent(ctx, 300);
+            dasher_set_screen_size(ctx, 800, 600);
+
+            unsigned long t = 1000;
+            char stage[128];
+            scenarios++;
+
+            dasher_mouse_move(ctx, 700.0f, 300.0f);
+            dasher_mouse_down(ctx);
+            steer(ctx, 700.0f, 285.0f, 220, t);
+            steer(ctx, 700.0f, 300.0f, 120, t);
+            steer(ctx, 700.0f, 288.0f, 180, t);
+            snprintf(stage, sizeof(stage), "rev=%d pause=%d after-forward1", rev, pause);
+            if (!check(ctx, stage, failures)) {
+                dasher_destroy(ctx);
+                continue;
+            }
+
+            if (pause) dasher_mouse_up(ctx);
+            steer(ctx, 60.0f, 300.0f, rev, t);
+            if (pause) dasher_mouse_down(ctx);
+            snprintf(stage, sizeof(stage), "rev=%d pause=%d after-reverse", rev, pause);
+            if (!check(ctx, stage, failures)) {
+                dasher_destroy(ctx);
+                continue;
+            }
+
+            steer(ctx, 700.0f, 285.0f, 160, t);
+            steer(ctx, 700.0f, 300.0f, 120, t);
+            snprintf(stage, sizeof(stage), "rev=%d pause=%d after-forward2", rev, pause);
+            check(ctx, stage, failures);
+
+            dasher_mouse_up(ctx);
+            dasher_destroy(ctx);
+        }
+    }
+
+    printf("  scenarios: %d, failures: %d\n", scenarios, failures);
+    ASSERT_EQ(failures, 0);
+}


### PR DESCRIPTION
## Summary
- Regression guard for Direct Mode (RFC 0015): replaying the output callback's deltas (0=insert, 1=delete-as-backspaces-per-code-point, 2=clear) into a shadow buffer must always reproduce `dasher_get_output_text()` byte-for-byte
- 20 scenarios: shallow (≈one word) through deep reversals, with and without pointer-up pauses

## Investigation context
This test was written while investigating a Dasher-Windows build .24 report (*"zoom back to delete a word or a bunch of words, zoom forward again — it messes up just the previous word"*). The invariant **holds on both v0.1.6** (the pin .24 shipped with) **and current main** — the engine's insert/delete stream is consistent. The corruption was the Windows newline-injection path (fixed in Dasher-Windows bfdafb4: `KEYEVENTF_UNICODE` 0x0A is ignored by target apps; now mapped to `VK_RETURN`), which made paragraph-node deletes eat a character of the preceding word.

Kept as a permanent guard: any future engine-side drift in the delete/re-emit path breaks direct mode on every frontend.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a Direct Mode regression test that replays output callback events into a shadow buffer and checks that it remains byte-for-byte consistent with the engine’s output across forward/reverse/forward navigation.
- Registers the new test executable with CMake and CTest.
- Exercises 20 reversal-depth and pointer-pause scenarios.
- Validates insert, Unicode-aware delete, and clear callback events against polled output text.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CMakeLists.txt | Registers the Direct Mode shadow-buffer regression executable through the existing public C API test helper. |
| tests/test_direct_mode_shadow.cpp | Adds a callback-replay invariant test covering twenty forward/reverse/forward navigation scenarios. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant Engine as DasherCore
    participant Shadow as Shadow buffer
    Test->>Engine: Drive forward navigation
    Engine-->>Shadow: Insert callbacks
    Test->>Engine: Drive reverse navigation
    Engine-->>Shadow: Delete callbacks
    Test->>Engine: Drive forward again
    Engine-->>Shadow: Re-emitted insert callbacks
    Test->>Engine: dasher_get_output_text()
    Test->>Shadow: Compare byte-for-byte
    Shadow-->>Test: Matching invariant
```
</details>

<sub>Reviews (2): Last reviewed commit: ["style: clang-format; switch to ScopedCon..."](https://github.com/dasher-project/dashercore/commit/85fa74401c016fa36059ff7cf85ce92394950ca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58843698)</sub>

<!-- /greptile_comment -->