### PR TITLE
fix(colours): v6 palettes without label sequences inherit the parent's labels

### DIFF
--- a/src/DasherCore/ColorIO.cpp
+++ b/src/DasherCore/ColorIO.cpp
@@ -230,6 +230,24 @@ bool CColorIO::Parse(pugi::xml_document& document, const std::string, bool bUser
         group.nodeLabelColorSequence = GetAttributeAsColorList(groupInfo.attribute("nodeLabelColorSequence"));
         group.altNodeLabelColorSequence = GetAttributeAsColorList(groupInfo.attribute("altNodeLabelColorSequence"));
 
+        // A v6 palette authored with only defaultLabelColor expects it to
+        // colour every label (v5 semantics — ParseLegacy does the same when
+        // it builds its groups). Without this, label resolution falls through
+        // the empty sequences to the PARENT palette's group-specific label
+        // colours, which broke "Yellow on Black" (#47): the dark legacy
+        // Default palette supplied black labels that vanished on the dark
+        // background. Defaulting to the palette's own defaultLabel keeps
+        // each file self-contained; explicit per-group sequences still win.
+        if (group.groupLabelColor.first == ColorPalette::undefinedColor &&
+            group.groupLabelColor.second == ColorPalette::undefinedColor) {
+            if (auto it = NamedColors.find(NamedColor::defaultLabel); it != NamedColors.end())
+                group.groupLabelColor.first = it->second;
+        }
+        if (group.nodeLabelColorSequence.empty() && group.altNodeLabelColorSequence.empty()) {
+            if (auto it = NamedColors.find(NamedColor::defaultLabel); it != NamedColors.end())
+                group.nodeLabelColorSequence.push_back(it->second);
+        }
+
         GroupColors[groupInfo.attribute("name").as_string()] = group;
     }
 

--- a/tests/test_draw_commands.cpp
+++ b/tests/test_draw_commands.cpp
@@ -305,3 +305,44 @@ TEST(uppercase_group_box_has_distinct_colour) {
 
     dasher_destroy(ctx);
 }
+
+TEST(yellow_on_black_labels_carry_palette_default_label_colour) {
+    // Regression (#47 - "Yellow on Black renders all black, no yellow
+    // anywhere"): the v6 palette files author only defaultLabelColor and no
+    // per-group label sequences. Label resolution fell through the empty
+    // sequences to the PARENT palette's group-specific label colours - the
+    // legacy Default palette supplies black - so labels vanished on the dark
+    // background. The v6 parser now defaults empty group label colours to
+    // the palette's OWN defaultLabel (v5 semantics, mirroring ParseLegacy).
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    dasher_set_palette(ctx, "Yellow on Black");
+    const char* active = dasher_get_current_palette(ctx);
+    ASSERT_STR_EQ(active, "Yellow on Black");
+
+    run_frames(ctx, 30);
+
+    int* cmds;
+    int cmd_count;
+    char** strs;
+    int str_count;
+    dasher_frame(ctx, 1000 + 31 * 16, &cmds, &cmd_count, &strs, &str_count);
+
+    int text_cmds = 0;
+    int yellow = 0;
+    for (int i = 0; i + 5 < cmd_count; i += 6) {
+        if (cmds[i] != 5) continue; // text
+        text_cmds++;
+        const int argb = cmds[i + 5];
+        if (((argb >> 24) & 0xFF) == 255 && ((argb >> 16) & 0xFF) == 255 && ((argb >> 8) & 0xFF) == 255 &&
+            (argb & 0xFF) == 0)
+            yellow++; // #FFFFFF00
+    }
+    printf("  text cmds=%d yellow=%d\n", text_cmds, yellow);
+    ASSERT(text_cmds > 0);
+    ASSERT(yellow == text_cmds); // every label, not just some
+
+    dasher_destroy(ctx);
+}


### PR DESCRIPTION
## Summary

Fixes Dasher-Windows #47: "Yellow on Black colour theme — it's all black. The font is not yellow. There is no yellow anywhere."

### Root cause

The v6 palette files (`Data/colors/color.*.xml`, RFC 0007) are authored with only `defaultLabelColor` and no per-group label sequences. Label resolution in `GetNodeLabelColor`/`GetGroupLabelColor` treats the empty sequences as "undefined" and falls through to the **parent palette** — whose group-specific label colours win *before* the child palette's own `defaultLabel` fallback can run. For "Yellow on Black" (`parentName="Default"`), the legacy Default palette supplies **black** labels → invisible on the dark background.

### Fix

The v6 parser now defaults empty group label colours (`groupLabelColor` / `nodeLabelColorSequence`) to the palette's **own** `defaultLabelColor` — mirroring what `ParseLegacy` has always done when building its groups (ColorIO.cpp:105-128). Explicit per-group sequences still win; palettes that don't define `defaultLabelColor` keep the previous parent-inheritance behaviour.

### Regression test

`yellow_on_black_labels_carry_palette_default_label_colour` (test_draw_commands.cpp): with "Yellow on Black" selected, every opcode-5 text command must be `#FFFFFF00`. Measured pre-fix: all `#FF000000`; post-fix: 21/21 yellow.

Full suite: 40/40 test executables green (incl. the #63 uppercase-colour regression, which shares this code path).

### Notes

- Not related to #63 (that fixed *box* colours via parse-order and legacy group defaults; this fixes *label* colour defaulting) — but the same family of "palette authored expecting v5 defaults".
- Dasher-GTK/Android/Apple consume the same palettes through the same parser — all frontends benefit.

## Type of change
- [x] Bug fix

## Definition of Done
- [x] 40/40 engine test suites green
- [x] Regression test added
- [x] clang-format clean
- [x] DCO signed


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates v6 palette parsing so groups with no explicit label colors use their palette’s own `defaultLabelColor`, preventing parent group colors from overriding intended high-contrast labels.

- Defaults wholly unspecified group and node label colors during parsing.
- Preserves explicit label sequences and existing inheritance when no palette-local default exists.
- Adds an end-to-end draw-command regression test for Yellow on Black.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The parser change is scoped to wholly unspecified label colors, preserves explicit definitions and no-default inheritance, and the regression test exercises the resulting frontend-visible draw commands.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/DasherCore/ColorIO.cpp | Defaults wholly empty v6 group and node label definitions from the current palette while retaining explicit values and inheritance when no local default exists. |
| tests/test_draw_commands.cpp | Adds public-API rendering coverage that verifies every emitted Yellow on Black text command uses the palette’s yellow label color. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[v6 palette group] --> B{Explicit label colors?}
  B -->|Yes| C[Use explicit group or node colors]
  B -->|No| D{Palette defines defaultLabelColor?}
  D -->|Yes| E[Materialize palette-local label default]
  D -->|No| F[Retain parent inheritance]
  C --> G[Render labels]
  E --> G
  F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(colours): v6 palettes without label ..."](https://github.com/dasher-project/dashercore/commit/7b7b7ea2f459a89b42203867a5d9b4ac14c7e05f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58989589)</sub>

**Context used:**

- Knowledge Base — [Visual and control assets](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/visual-and-control-assets.md)
- Knowledge Base — [Automated testing](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/automated-testing.md)

<!-- /greptile_comment -->